### PR TITLE
rebuild lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1030,14 +1030,14 @@
       }
     },
     "@wdio/config": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.24.0.tgz",
-      "integrity": "sha512-MSIuwbs7JeOh9eMiFP3nVYDyaK3jYv7HY4eJIfvl6TBo4G1mTjbF1Dnct38W0ZR5WIFeSKhl15LiumbNUv0pyA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.25.4.tgz",
+      "integrity": "sha512-vb0emDtD9FbFh/yqW6oNdo2iuhQp8XKj6GX9fyy9v4wZgg3B0HPMVJxhIfcoHz7LMBWlHSo9YdvhFI5EQHRLBA==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.24.0",
-        "@wdio/utils": "7.24.0",
+        "@wdio/types": "7.25.4",
+        "@wdio/utils": "7.25.4",
         "deepmerge": "^4.0.0",
         "glob": "^8.0.3"
       },
@@ -1094,18 +1094,18 @@
       "dev": true
     },
     "@wdio/repl": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.24.0.tgz",
-      "integrity": "sha512-DloYlOMCgENnWk4PWDqCkZCieHdl1BwSc/EOU3czQMt4KV8qTm1SyMbeCSgaAjVWiNEYTkRodupia2sJGYtIJA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.25.4.tgz",
+      "integrity": "sha512-kYhj9gLsUk4HmlXLqkVre+gwbfvw9CcnrHjqIjrmMS4mR9D8zvBb5CItb3ZExfPf9jpFzIFREbCAYoE9x/kMwg==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "7.24.0"
+        "@wdio/utils": "7.25.4"
       }
     },
     "@wdio/types": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.24.0.tgz",
-      "integrity": "sha512-wJZ+1lIHFz5aWXSO+k91wX8tfZdpyX4YYoker5xfC4zvM7ypyK81dZyiE5whS+QFL3VTCPP8dXNjwX5f5h+YEw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.25.4.tgz",
+      "integrity": "sha512-muvNmq48QZCvocctnbe0URq2FjJjUPIG4iLoeMmyF0AQgdbjaUkMkw3BHYNHVTbSOU9WMsr2z8alhj/I2H6NRQ==",
       "dev": true,
       "requires": {
         "@types/node": "^18.0.0",
@@ -1113,13 +1113,13 @@
       }
     },
     "@wdio/utils": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.24.0.tgz",
-      "integrity": "sha512-VWfFT1Ket3pAt19kY5lPRuwJDheKF4hMwG0AiezkqqerDl/m+fcb4a6pj1WHjlawvlYM4MM15iBZFxYfphG9lg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.25.4.tgz",
+      "integrity": "sha512-8iwQDk+foUqSzKZKfhLxjlCKOkfRJPNHaezQoevNgnrTq/t0ek+ldZCATezb9B8jprAuP4mgS9xi22akc6RkzA==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.24.0",
+        "@wdio/types": "7.25.4",
         "p-iteration": "^1.1.8"
       }
     },
@@ -1390,9 +1390,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1218.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1218.0.tgz",
-      "integrity": "sha512-oreF2jKfUZ8VKnIKh8TrOOOsdSfv87jHGtWQNAHdvfeyrYK5FrnvGkHUZ3bu6g6u1gHwu5FhTPiRMbgS8Re+NA==",
+      "version": "2.1244.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1244.0.tgz",
+      "integrity": "sha512-V7uXdz3Koti2FfU07Xj6SGnv4UVIGcw03aEGLiidieilQYYVrny828pn2Pl2X9AWJJczE/iLzge/ITTJ7ZPwZQ==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -2063,58 +2063,11 @@
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
       "dev": true
     },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "dev": true
-    },
-    "d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "dev": true
-    },
-    "d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
-      "dev": true
-    },
-    "d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "dev": true
-    },
-    "d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "dev": true,
-      "requires": {
-        "d3-color": "1"
-      }
-    },
     "d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
       "dev": true
-    },
-    "d3-scale": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-      "dev": true,
-      "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
     },
     "d3-shape": {
       "version": "1.3.7",
@@ -2123,21 +2076,6 @@
       "dev": true,
       "requires": {
         "d3-path": "1"
-      }
-    },
-    "d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "dev": true
-    },
-    "d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "dev": true,
-      "requires": {
-        "d3-time": "1"
       }
     },
     "data-urls": {
@@ -2245,30 +2183,38 @@
       "dev": true
     },
     "devtools": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.24.0.tgz",
-      "integrity": "sha512-QcUacRC+qf5cNGkiWAO/HM+0pM4onlYL7+AafZfpZVN8GOhrvWHeyzM9mxmlMwM+aU2NcRK+cYVCbB0gZL9MGA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.25.4.tgz",
+      "integrity": "sha512-R6/S/dCqxoX4Y6PxIGM9JFAuSRZzUeV5r+CoE/frhmno6mTe7dEEgwkJlfit3LkKRoul8n4DsL2A3QtWOvq5IA==",
       "dev": true,
       "requires": {
         "@types/node": "^18.0.0",
         "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.24.0",
+        "@wdio/config": "7.25.4",
         "@wdio/logger": "7.19.0",
         "@wdio/protocols": "7.22.0",
-        "@wdio/types": "7.24.0",
-        "@wdio/utils": "7.24.0",
+        "@wdio/types": "7.25.4",
+        "@wdio/utils": "7.25.4",
         "chrome-launcher": "^0.15.0",
         "edge-paths": "^2.1.0",
         "puppeteer-core": "^13.1.3",
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^1.0.1",
-        "uuid": "^8.0.0"
+        "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "dev": true
+        }
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1040073",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1040073.tgz",
-      "integrity": "sha512-+iipnm2hvmlWs4MVNx7HwSTxhDxsXnQyK5F1OalZVXeUhdPgP/23T42NCyg0TK3wL/Yg92SVrSuGKqdg12o54w==",
+      "version": "0.0.1061995",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1061995.tgz",
+      "integrity": "sha512-pKZZWTjWa/IF4ENCg6GN8bu/AxSZgdhjSa26uc23wz38Blt2Tnm9icOPcSG3Cht55rMq35in1w3rWVPcZ60ArA==",
       "dev": true
     },
     "diff-sequences": {
@@ -6826,42 +6772,42 @@
       }
     },
     "webdriver": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.24.0.tgz",
-      "integrity": "sha512-AIxBLHz2b/ymDssWNcncOa3rh5KerGKuhIBSgtnxQ5joHb0W+iLVvR6uLytp1jqXodDmnjz1H+lVzgY/gxEa2A==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.25.4.tgz",
+      "integrity": "sha512-6nVDwenh0bxbtUkHASz9B8T9mB531Fn1PcQjUGj2t5dolLPn6zuK1D7XYVX40hpn6r3SlYzcZnEBs4X0az5Txg==",
       "dev": true,
       "requires": {
         "@types/node": "^18.0.0",
-        "@wdio/config": "7.24.0",
+        "@wdio/config": "7.25.4",
         "@wdio/logger": "7.19.0",
         "@wdio/protocols": "7.22.0",
-        "@wdio/types": "7.24.0",
-        "@wdio/utils": "7.24.0",
+        "@wdio/types": "7.25.4",
+        "@wdio/utils": "7.25.4",
         "got": "^11.0.2",
         "ky": "0.30.0",
         "lodash.merge": "^4.6.1"
       }
     },
     "webdriverio": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.24.0.tgz",
-      "integrity": "sha512-6V4+KS1SHE04+daV71TSJCd3RhPihbA5ShxV1tRCNxqdqzLD7XLxksPWvini9ieeZ9jmt7q4/SgBM8MY+08d6A==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.25.4.tgz",
+      "integrity": "sha512-agkgwn2SIk5cAJ03uue1GnGZcUZUDN3W4fUMY9/VfO8bVJrPEgWg31bPguEWPu+YhEB/aBJD8ECxJ3OEKdy4qQ==",
       "dev": true,
       "requires": {
         "@types/aria-query": "^5.0.0",
         "@types/node": "^18.0.0",
-        "@wdio/config": "7.24.0",
+        "@wdio/config": "7.25.4",
         "@wdio/logger": "7.19.0",
         "@wdio/protocols": "7.22.0",
-        "@wdio/repl": "7.24.0",
-        "@wdio/types": "7.24.0",
-        "@wdio/utils": "7.24.0",
+        "@wdio/repl": "7.25.4",
+        "@wdio/types": "7.25.4",
+        "@wdio/utils": "7.25.4",
         "archiver": "^5.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.24.0",
-        "devtools-protocol": "^0.0.1040073",
+        "devtools": "7.25.4",
+        "devtools-protocol": "^0.0.1061995",
         "fs-extra": "^10.0.0",
         "grapheme-splitter": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
@@ -6874,13 +6820,13 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
-        "webdriver": "7.24.0"
+        "webdriver": "7.25.4"
       },
       "dependencies": {
         "@types/aria-query": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-P+dkdFu0n08PDIvw+9nT9ByQnd+Udc8DaWPb9HKfaPwCvWvQpC5XaMRx2xLWECm9x1VKNps6vEAlirjA6+uNrQ==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+          "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
           "dev": true
         },
         "brace-expansion": {


### PR DESCRIPTION
### Description

`@cloudscape-design/*` packages are not inside package-lock, but some of their dependencies are, and we need to regenerate file sometimes

### How has this been tested?

PR build

### Documentation changes


- [ ] _Yes, this change contains documentation changes._
- [x] _No._


### Related links

PRs with dependency upgrades in downstream packages

* https://github.com/cloudscape-design/browser-test-tools/pull/20
* https://github.com/cloudscape-design/components/pull/399

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
