### PR TITLE
Make public components and interfaces exports proxied via main index.ts

### DIFF
--- a/pages/canvas/layouts.page.tsx
+++ b/pages/canvas/layouts.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import Canvas from "../../lib/components/canvas";
-import { CanvasLayoutItem } from "../../lib/components/internal/layout";
+
+import { Canvas, CanvasLayoutItem } from "../../lib/components";
 import { TestBed } from "../app/test-bed";
 import classnames from "./layouts.module.css";
 

--- a/pages/dnd/engine.page.tsx
+++ b/pages/dnd/engine.page.tsx
@@ -8,7 +8,7 @@ import clsx from "clsx";
 import { CSSProperties, useState } from "react";
 import { calculateShifts, createTransforms } from "./layout";
 import { initialItems, Item } from "./items";
-import Canvas from "../../lib/components/canvas";
+import { Canvas } from "../../lib/components";
 import { canvasItemsToLayout, layoutToCanvasItems } from "../../lib/components/internal/layout";
 
 const columnsCount = 4;

--- a/pages/dnd/items.ts
+++ b/pages/dnd/items.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import * as awsuiTokens from "@cloudscape-design/design-tokens";
-import { CanvasLayoutItem } from "../../lib/components/internal/layout";
+import { CanvasLayoutItem } from "../../lib/components";
 
 export interface ItemData {
   color: string;

--- a/pages/grid/with-widget-containers.page.tsx
+++ b/pages/grid/with-widget-containers.page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Header } from "@cloudscape-design/components";
 import Grid, { GridProps } from "../../lib/components/internal/grid";
-import WidgetContainer from "../../lib/components/widget-container";
+import { WidgetContainer } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";
 import { widgetContainer } from "../shared/i18n";

--- a/pages/shared/i18n.ts
+++ b/pages/shared/i18n.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { WidgetContainerProps } from "../../lib/components/widget-container";
+import type { WidgetContainerProps } from "../../lib/components";
 
 export const widgetContainer: WidgetContainerProps["i18nStrings"] = {
   dragHandleLabel: "Drag handle",

--- a/pages/widget-container/keyboard.page.tsx
+++ b/pages/widget-container/keyboard.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import WidgetContainer from "../../lib/components/widget-container";
+
+import { WidgetContainer } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";
 import { widgetContainer } from "../shared/i18n";

--- a/pages/widget-container/permutations.page.tsx
+++ b/pages/widget-container/permutations.page.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, ButtonDropdown, SpaceBetween } from "@cloudscape-design/components";
 import Header from "@cloudscape-design/components/header";
 
-import WidgetContainer from "../../lib/components/widget-container";
+import { WidgetContainer } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";
 import { widgetContainer } from "../shared/i18n";

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,4 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-export { default as default } from "./canvas";
-export type { CanvasProps } from "./interfaces";

--- a/src/canvas/index.tsx
+++ b/src/canvas/index.tsx
@@ -6,7 +6,7 @@ import type { DataFallbackType } from "../interfaces";
 import { CanvasProps } from "./interfaces";
 import Placeholder from "./placeholder";
 import useGridLayout from "./use-grid-layout";
-import useContainerQuery from "../internal/use-container-query/index";
+import useContainerQuery from "../internal/use-container-query";
 import { BREAKPOINT_SMALL, COLUMNS_FULL, COLUMNS_SMALL } from "../constants";
 
 export default function Canvas<D = DataFallbackType>({ items, renderItem }: CanvasProps<D>) {

--- a/src/canvas/interfaces.ts
+++ b/src/canvas/interfaces.ts
@@ -7,3 +7,5 @@ export interface CanvasProps<D = DataFallbackType> {
   items: readonly CanvasLayoutItem<D>[];
   renderItem(item: CanvasLayoutItem<D>): React.ReactNode;
 }
+
+export type { CanvasLayoutItem };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-export type { WidgetContainerProps } from "./widget-container";
+
+export type { CanvasProps, CanvasLayoutItem } from "./canvas/interfaces";
+export { default as Canvas } from "./canvas";
+
+export type { WidgetContainerProps } from "./widget-container/interfaces";
 export { default as WidgetContainer } from "./widget-container";

--- a/src/widget-container/index.tsx
+++ b/src/widget-container/index.tsx
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import Container from "@cloudscape-design/components/container";
-import DragHandle from "../internal/drag-handle/index";
+import DragHandle from "../internal/drag-handle";
 import type { WidgetContainerProps } from "./interfaces";
 import WidgetContainerHeader from "./header";
 import ResizeHandle from "../internal/resize-handle";
 import styles from "./styles.css.js";
-
-export type { WidgetContainerProps };
 
 export default function WidgetContainer(props: WidgetContainerProps) {
   const { children, header, settings, i18nStrings, ...containerProps } = props;


### PR DESCRIPTION
### Description

Make the src structure better uniform.

* Public components are [component-name]/index.tsx
* Public component interfaces are [component-name]/interfaces.ts

All public components and interfaces are also proxied via index.tsx

Do we want to use namespaces for types?

### How has this been tested?

[_How did you test to verify your changes?_]

[_How can reviewers test these changes efficiently?_]

### Documentation changes

[*Do the changes include any API documentation changes?*]
- [ ] _Yes, this change contains documentation changes._
- [ ] _No._

### Related Links

[*Attach any related links/pull request for this change*]


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
