### PR TITLE
add rule for named imports order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -68,6 +68,7 @@
         ]
       }
     ],
+    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "import/order": ["error", { "alphabetize": { "order": "asc" } }],
     "import/no-useless-path-segments": [
       "warn",

--- a/pages/dnd/engine.page.tsx
+++ b/pages/dnd/engine.page.tsx
@@ -4,7 +4,7 @@ import Box from "@cloudscape-design/components/box";
 import Header from "@cloudscape-design/components/header";
 import { useState } from "react";
 import { DashboardItem, DashboardItemProps, DashboardLayout } from "../../lib/components";
-import { initialItems, Item } from "./items";
+import { Item, initialItems } from "./items";
 
 const itemStrings: DashboardItemProps["i18nStrings"] = {
   dragHandleLabel: "Drag me",

--- a/pages/grid/permutations.page.tsx
+++ b/pages/grid/permutations.page.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 import Grid from "../../lib/components/internal/grid";
 import { TestBed } from "../app/test-bed";
-import { chess, jenga, cross, dashboard } from "./layouts";
+import { chess, cross, dashboard, jenga } from "./layouts";
 
 import classnames from "./permutations.module.css";
 

--- a/scripts/compile-styles.js
+++ b/scripts/compile-styles.js
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { buildThemedComponentsInternal, ThemeBuilder } from "@cloudscape-design/theming-build";
+import { ThemeBuilder, buildThemedComponentsInternal } from "@cloudscape-design/theming-build";
 
 await buildThemedComponentsInternal({
   primary: new ThemeBuilder("unused", ":root", []).build(),

--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { DraggableSyntheticListeners } from "@dnd-kit/core";
-import { forwardRef, ForwardedRef } from "react";
+import { ForwardedRef, forwardRef } from "react";
 
 import Handle from "../handle";
 import DragHandleIcon from "./icon";

--- a/src/internal/grid/grid.test.tsx
+++ b/src/internal/grid/grid.test.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { render } from "@testing-library/react";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 import Grid, { GridProps } from "../../../lib/components/internal/grid";
 import gridStyles from "../../../lib/components/internal/grid/styles.selectors";
 

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ReactNode, Children } from "react";
+import { Children, ReactNode } from "react";
 
 import { GridLayoutItem } from "../layout";
 import { GridProps } from "./interfaces";

--- a/src/internal/handle/index.tsx
+++ b/src/internal/handle/index.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
-import { forwardRef, ForwardedRef, ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, ForwardedRef, forwardRef } from "react";
 import styles from "./styles.css.js";
 
 function Handle(props: ButtonHTMLAttributes<HTMLButtonElement>, ref: ForwardedRef<HTMLButtonElement>) {

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { forwardRef, ForwardedRef } from "react";
+import { ForwardedRef, forwardRef } from "react";
 
 import Handle from "../handle";
 import { ResizeHandleIcon } from "./icon";

--- a/src/internal/use-container-query/index.ts
+++ b/src/internal/use-container-query/index.ts
@@ -3,7 +3,7 @@
 
 /** Temporarily taken from Component Toolkit until available in NPM */
 import { ResizeObserver, ResizeObserverEntry } from "@juggle/resize-observer";
-import { useRef, useEffect, useLayoutEffect, useState, useCallback, DependencyList, Ref, RefObject } from "react";
+import { DependencyList, Ref, RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * A callback that stays stable between renders even as the dependencies change.

--- a/src/item/__tests__/dashboard-item.test.tsx
+++ b/src/item/__tests__/dashboard-item.test.tsx
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render as libRender, cleanup } from "@testing-library/react";
+import { cleanup, render as libRender } from "@testing-library/react";
 import { ReactElement } from "react";
-import { describe, test, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { ItemContextProvider } from "../../../lib/components/internal/item-context";
 import type { DashboardItemProps } from "../../../lib/components/item";
 import DashboardItem from "../../../lib/components/item";

--- a/src/item/index.tsx
+++ b/src/item/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import Container from "@cloudscape-design/components/container";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { useCombinedRefs, CSS as CSSUtil } from "@dnd-kit/utilities";
+import { CSS as CSSUtil, useCombinedRefs } from "@dnd-kit/utilities";
 import clsx from "clsx";
 import { CSSProperties } from "react";
 import DragHandle from "../internal/drag-handle";

--- a/src/layout/collision.ts
+++ b/src/layout/collision.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CollisionDetection, ClientRect } from "@dnd-kit/core";
+import { ClientRect, CollisionDetection } from "@dnd-kit/core";
 
 function withinBounds(rect: ClientRect, [top, left, right, bottom]: readonly [number, number, number, number]) {
   return rect.top <= top && rect.left >= left && rect.right <= right && rect.bottom >= bottom;

--- a/src/layout/create-grid-layout.ts
+++ b/src/layout/create-grid-layout.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createGridItems, createGridPlaceholders, GridLayoutItem } from "../internal/layout";
+import { GridLayoutItem, createGridItems, createGridPlaceholders } from "../internal/layout";
 import { DashboardLayoutProps } from "./interfaces";
 
 interface GridLayoutConfig {

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { startWebdriver, shutdownWebdriver } from "@cloudscape-design/browser-test-tools/chrome-launcher";
+import { shutdownWebdriver, startWebdriver } from "@cloudscape-design/browser-test-tools/chrome-launcher";
 
 export const setup = () => startWebdriver();
 export const teardown = () => shutdownWebdriver();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import useBrowser from "@cloudscape-design/browser-test-tools/use-browser";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 import { routes } from "../pages/pages";
 
 function setupTest(testFn: (browser: ScreenshotPageObject["browser"]) => Promise<void>) {

--- a/test/widget-container/keyboard.test.ts
+++ b/test/widget-container/keyboard.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import useBrowser from "@cloudscape-design/browser-test-tools/use-browser";
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
 
 function setupTest(testFn: (browser: ScreenshotPageObject) => Promise<void>) {
   return useBrowser(async (browser) => {


### PR DESCRIPTION
### Description

Follow up for https://github.com/cloudscape-design/dashboard-components/pull/33

Turns out that named imports order is validated by another rule: https://github.com/import-js/eslint-plugin-import/issues/1732#issuecomment-616246894

Why do we need two rules instead of one? Because `sync-imports` cannot auto-fix lines order. So `import/order` sorts  lines and then `sync-imports` sorts named imports inside

### How has this been tested?

`npm run lint -- --fix`. The result is in this PR

### Documentation changes

- [ ] _Yes, this change contains documentation changes._
- [x] _No._


<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- [ ] _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- [ ] _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- [ ] _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/).

#### Testing

- [ ] _Changes are covered with new/existing unit tests?_
- [ ] _Changes are covered with new/existing integration tests?_
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
