### PR TITLE
chore: upgrade vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7158,22 +7158,25 @@
       }
     },
     "vitest": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.23.4.tgz",
-      "integrity": "sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.25.2.tgz",
+      "integrity": "sha512-qqkzfzglEFbQY7IGkgSJkdOhoqHjwAao/OrphnHboeYHC5JzsVFoLCaB2lnAy8krhj7sbrFTVRApzpkTOeuDWQ==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.3",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
         "chai": "^4.3.6",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.2",
-        "strip-literal": "^0.4.1",
-        "tinybench": "^2.1.5",
+        "source-map": "^0.6.1",
+        "strip-literal": "^0.4.2",
+        "tinybench": "^2.3.1",
         "tinypool": "^0.3.0",
         "tinyspy": "^1.0.2",
-        "vite": "^2.9.12 || ^3.0.0-0"
+        "vite": "^3.0.0"
       }
     },
     "w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-router-dom": "^6.4.3",
     "typescript": "^4.9.3",
     "vite": "^3.2.4",
-    "vitest": "^0.23.4"
+    "vitest": "^0.25.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/internal/grid/__tests__/grid.test.tsx
+++ b/src/internal/grid/__tests__/grid.test.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { render } from "@testing-library/react";
 import { expect, test } from "vitest";
-import Grid, { GridProps } from "../../../lib/components/internal/grid";
-import gridStyles from "../../../lib/components/internal/grid/styles.selectors.js";
+import Grid, { GridProps } from "../../../../lib/components/internal/grid";
+import gridStyles from "../../../../lib/components/internal/grid/styles.css.js";
 
 const defaultProps: GridProps = {
   rows: 1,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "strict": true
   },
   "include": ["src", "types"],
-  "exclude": ["**/*.test.tsx"]
+  "exclude": ["**/__tests__/**"]
 }

--- a/vite.e2e.config.js
+++ b/vite.e2e.config.js
@@ -9,8 +9,8 @@ export default defineConfig({
   root: "./",
   test: {
     environment: "node",
-    dir: "./test",
     testTimeout: 60000,
+    include: ["./test/**/*.test.ts"],
     setupFiles: ["./test/test-setup.ts"],
     globalSetup: ["./test/global-setup.ts"],
   },

--- a/vite.unit.config.js
+++ b/vite.unit.config.js
@@ -6,8 +6,9 @@ import base from "./vite.config.js";
 // https://vitejs.dev/config/
 export default defineConfig({
   ...base,
+  root: "./",
   test: {
+    include: ["./src/**/__tests__/**/*.test.{ts,tsx}"],
     environment: "jsdom",
-    dir: "./src",
   },
 });


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

An addition to https://github.com/cloudscape-design/dashboard-components/pull/46. Putting vitest in a separate PR, because there are some breaking changes needed manual changes.

Related change in vitest: https://github.com/vitest-dev/vitest/pull/2226. Their new behavior is more correct, because it is closer how node.js handles the same esm-commonjs imports


### How has this been tested?

PR build, local

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
