### PR TITLE
Fix grid generator bug

### DIFF
--- a/src/internal/dnd-engine/debug-tools/generators.ts
+++ b/src/internal/dnd-engine/debug-tools/generators.ts
@@ -59,7 +59,7 @@ export function generateGrid(options?: GenerateGridOptions): GridDefinition {
     const index = getRandomIndex(items);
 
     if (selectedAllowance === "horizontal") {
-      items[index].width++;
+      items[index].width = Math.min(width - items[index].x, items[index].width + 1);
       for (let i = 0; i < items[index].height; i++) {
         allowance.horizontal--;
       }


### PR DESCRIPTION
### Description

Fix a bug where grid gen created items with width exceeding the grid bounds.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
