### PR TITLE
Trigger refloat after every d&d action

### DIFF
--- a/src/internal/dnd-engine/__tests__/engine-float.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-float.test.ts
@@ -3,7 +3,8 @@
 
 import { expect, test } from "vitest";
 import { fromMatrix, fromTextPath, generateGrid, generateMove, toMatrix } from "../debug-tools";
-import { forEachTimes, withCommit } from "./helpers";
+import { DndEngine } from "../engine";
+import { forEachTimes } from "./helpers";
 
 test("all items float to the top after move+commit", () => {
   forEachTimes(
@@ -16,7 +17,7 @@ test("all items float to the top after move+commit", () => {
     ([width, totalItems]) => {
       const grid = generateGrid({ width, totalItems });
       const movePath = generateMove(grid, "any");
-      const transition = withCommit(grid, (engine) => engine.move(movePath));
+      const transition = new DndEngine(grid).move(movePath);
 
       if (transition.blocks.length === 0) {
         const textGrid = toMatrix(transition.end);
@@ -50,8 +51,7 @@ test("float creates addition moves", () => {
     [" ", " ", "F", "G"],
     [" ", " ", "H", " "],
   ]);
-  const transition = withCommit(grid, (engine) => engine.move(fromTextPath("C2 B2 A2", grid)));
-
+  const transition = new DndEngine(grid).move(fromTextPath("C2 B2 A2", grid));
   expect(transition.moves).toEqual([
     { itemId: "E", y: 1, x: 1, type: "USER" },
     { itemId: "E", y: 1, x: 0, type: "USER" },

--- a/src/internal/dnd-engine/__tests__/engine-insert.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-insert.test.ts
@@ -4,13 +4,13 @@
 import { range } from "lodash";
 import { describe, expect, test } from "vitest";
 import { fromMatrix, generateGrid, generateInsert, toString } from "../debug-tools";
-import { withCommit } from "./helpers";
+import { DndEngine } from "../engine";
 
 test("element insertion never leaves grid with unresolved conflicts", () => {
   range(0, 25).forEach(() => {
     const grid = generateGrid();
     const item = generateInsert(grid);
-    const transition = withCommit(grid, (engine) => engine.insert(item));
+    const transition = new DndEngine(grid).insert(item);
     expect(transition.blocks).toHaveLength(0);
   });
 });
@@ -49,7 +49,7 @@ describe("insert scenarios", () => {
       ],
     ],
   ])("%s", (_, grid, item, expectation) => {
-    const transition = withCommit(fromMatrix(grid), (engine) => engine.insert(item));
+    const transition = new DndEngine(fromMatrix(grid)).insert(item);
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });

--- a/src/internal/dnd-engine/__tests__/engine-move-1x1-items.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-move-1x1-items.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, test } from "vitest";
 import { fromMatrix, fromTextPath, toString } from "../debug-tools";
-import { withCommit } from "./helpers";
+import { DndEngine } from "../engine";
 
 describe("swap adjacent items", () => {
   test.each([
@@ -65,7 +65,7 @@ describe("swap adjacent items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -186,7 +186,7 @@ describe("replace closest diagonal items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -251,7 +251,7 @@ describe("swap distant items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -316,7 +316,7 @@ describe("replace distant diagonal items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -353,7 +353,7 @@ describe("replace arbitrary items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });

--- a/src/internal/dnd-engine/__tests__/engine-move-blocks.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-move-blocks.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, test } from "vitest";
 import { fromMatrix, fromTextPath, generateGrid, generateMove, toString } from "../debug-tools";
 import { DndEngine } from "../engine";
-import { forEachTimes, withCommit } from "./helpers";
+import { forEachTimes } from "./helpers";
 
 test("any move on a grid with 1x1 items only is resolved", () => {
   forEachTimes(
@@ -67,7 +67,7 @@ describe("swap right", () => {
     [[["A", "A", "B", "B", "B"]], "A1 B1 C1", [[" ", " ", "A/B", "A/B", "B"]]],
   ])("can't swap to the right when not enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -78,7 +78,7 @@ describe("swap right", () => {
     [[["A", "A", "B", "B", "B"]], "A1 B1 C1 D1", [["B", "B", "B", "A", "A"]]],
   ])("can swap to the right when enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -97,7 +97,7 @@ describe("swap right", () => {
     ],
   ])("can make partial swap to the right", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -112,7 +112,7 @@ describe("swap left", () => {
     [[["A", "A", "A", "B", "B"]], "D1 C1 B1", [["A", "A/B", "A/B", " ", " "]]],
   ])("can't swap to the left when not enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -123,7 +123,7 @@ describe("swap left", () => {
     [[["A", "A", "A", "B", "B"]], "D1 C1 B1 A1", [["B", "B", "A", "A", "A"]]],
   ])("can swap to the left when enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -142,7 +142,7 @@ describe("swap left", () => {
     ],
   ])("can make partial swap to the left", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -157,7 +157,7 @@ describe("swap bottom", () => {
     [[["A"], ["A"], ["B"], ["B"], ["B"]], "A1 A2 A3", [[" "], [" "], ["A/B"], ["A/B"], ["B"]]],
   ])("can't swap to the bottom when not enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -168,7 +168,7 @@ describe("swap bottom", () => {
     [[["A"], ["A"], ["B"], ["B"], ["B"]], "A1 A2 A3 A4", [["B"], ["B"], ["B"], ["A"], ["A"]]],
   ])("can swap to the bottom when enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -191,7 +191,7 @@ describe("swap bottom", () => {
     ],
   ])("can make partial swap to the bottom", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -206,7 +206,7 @@ describe("swap top", () => {
     [[["A"], ["A"], ["A"], ["B"], ["B"]], "A4 A3 A2", [["A"], ["A/B"], ["A/B"]]],
   ])("can't swap to the top when not enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -217,7 +217,7 @@ describe("swap top", () => {
     [[["A"], ["A"], ["A"], ["B"], ["B"]], "A4 A3 A2 A1", [["B"], ["B"], ["A"], ["A"], ["A"]]],
   ])("can swap to the top when enough overlap", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 
@@ -240,7 +240,7 @@ describe("swap top", () => {
     ],
   ])("can make partial swap to the top", (gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });

--- a/src/internal/dnd-engine/__tests__/engine-move-larger.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-move-larger.test.ts
@@ -4,7 +4,6 @@
 import { describe, expect, test } from "vitest";
 import { fromMatrix, fromTextPath, toString } from "../debug-tools";
 import { DndEngine } from "../engine";
-import { withCommit } from "./helpers";
 
 describe("vertical swaps of larger items", () => {
   test.each([
@@ -97,7 +96,7 @@ describe("vertical swaps of larger items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -149,7 +148,7 @@ describe("horizontal swaps of larger items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -199,17 +198,17 @@ describe("swaps with overlay", () => {
     [
       "swap S with D (overlay on the bottom)",
       [
-        [" ", "A"],
         ["S", "A"],
-        ["D", "B"],
-        ["D", "B"],
-      ],
-      "A2 A3 A4",
-      [
-        [" ", "A"],
         ["D", "A"],
         ["D", "B"],
+        [" ", "B"],
+      ],
+      "A1 A2 A3",
+      [
+        ["D", "A"],
+        ["D", "A"],
         ["S", "B"],
+        [" ", "B"],
       ],
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
@@ -255,7 +254,7 @@ describe("diagonal swaps of larger items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -298,7 +297,7 @@ describe("replacement moves of larger items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -325,7 +324,7 @@ describe("long path moves", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -395,7 +394,7 @@ describe("empty spaces are prioritized over disturbing other items", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });
@@ -422,7 +421,7 @@ describe("escape moves", () => {
     ],
   ])("%s", (_, gridMatrix, path, expectation, escapeMove) => {
     const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.move(fromTextPath(path, grid)));
+    const transition = new DndEngine(grid).move(fromTextPath(path, grid));
     expect(toString(transition.end)).toBe(toString(expectation));
     expect(transition.moves.find((move) => move.itemId === "B")).toEqual(escapeMove);
   });

--- a/src/internal/dnd-engine/__tests__/engine-remove.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-remove.test.ts
@@ -4,12 +4,12 @@
 import { range } from "lodash";
 import { describe, expect, test } from "vitest";
 import { fromMatrix, generateGrid, toString } from "../debug-tools";
-import { withCommit } from "./helpers";
+import { DndEngine } from "../engine";
 
 test("element removal never leaves grid with unresolved conflicts", () => {
   range(0, 25).forEach(() => {
     const grid = generateGrid();
-    const transition = withCommit(grid, (engine) => engine.remove("A"));
+    const transition = new DndEngine(grid).remove("A");
     expect(transition.blocks).toHaveLength(0);
   });
 });
@@ -30,8 +30,7 @@ describe("remove scenarios", () => {
       ],
     ],
   ])("%s", (_, gridMatrix, itemId, expectation) => {
-    const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.remove(itemId));
+    const transition = new DndEngine(fromMatrix(gridMatrix)).remove(itemId);
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });

--- a/src/internal/dnd-engine/__tests__/engine-resize.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-resize.test.ts
@@ -4,13 +4,13 @@
 import { range } from "lodash";
 import { describe, expect, test } from "vitest";
 import { fromMatrix, generateGrid, generateResize, toString } from "../debug-tools";
-import { withCommit } from "./helpers";
+import { DndEngine } from "../engine";
 
 test("decrease in element size never creates conflicts", () => {
   range(0, 10).forEach(() => {
     const grid = generateGrid();
     const resize = generateResize(grid, { maxWidthIncrement: 0, maxHeightIncrement: 0 });
-    const transition = withCommit(grid, (engine) => engine.resize(resize));
+    const transition = new DndEngine(grid).resize(resize);
     expect(transition.moves.filter((move) => move.type !== "FLOAT")).toHaveLength(0);
   });
 });
@@ -19,7 +19,7 @@ test("elements resize never leaves grid with unresolved conflicts", () => {
   range(0, 25).forEach(() => {
     const grid = generateGrid();
     const resize = generateResize(grid, { maxWidthDecrement: 0, maxHeightDecrement: 0 });
-    const transition = withCommit(grid, (engine) => engine.resize(resize));
+    const transition = new DndEngine(grid).resize(resize);
     expect(transition.blocks).toHaveLength(0);
   });
 });
@@ -58,8 +58,7 @@ describe("resize scenarios", () => {
       ],
     ],
   ])("%s", (_, gridMatrix, resize, expectation) => {
-    const grid = fromMatrix(gridMatrix);
-    const transition = withCommit(grid, (engine) => engine.resize(resize));
+    const transition = new DndEngine(fromMatrix(gridMatrix)).resize(resize);
     expect(toString(transition.end)).toBe(toString(expectation));
   });
 });

--- a/src/internal/dnd-engine/__tests__/engine-stateful.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-stateful.test.ts
@@ -113,19 +113,14 @@ test("commit does not happen when grid has unresolved conflicts", () => {
   );
 });
 
-test("commit triggers refloat", () => {
+test("move triggers refloat", () => {
   const grid = fromMatrix([
     ["A", "B", "C"],
     ["D", " ", "F"],
     ["G", " ", "E"],
   ]);
-  const engine = new DndEngine(grid);
-
-  const moveTransition = engine.move({ itemId: "F", path: [{ x: 1, y: 1 }] });
-  const moveRefloatTransition = engine.commit();
-
-  expect(moveTransition.moves).toEqual([{ itemId: "F", x: 1, y: 1, type: "USER" }]);
-  expect(moveRefloatTransition.moves).toEqual([
+  const transition = new DndEngine(grid).move({ itemId: "F", path: [{ x: 1, y: 1 }] });
+  expect(transition.moves).toEqual([
     { itemId: "F", x: 1, y: 1, type: "USER" },
     { itemId: "E", x: 2, y: 1, type: "FLOAT" },
   ]);

--- a/src/internal/dnd-engine/__tests__/engine-validation.test.ts
+++ b/src/internal/dnd-engine/__tests__/engine-validation.test.ts
@@ -138,6 +138,7 @@ test("normalizes move path and continues when from the repeating position", () =
     { itemId: "A", x: 1, y: 1, type: "USER" },
     { itemId: "A", x: 1, y: 2, type: "USER" },
     { itemId: "A", x: 1, y: 3, type: "USER" },
+    { itemId: "A", x: 1, y: 0, type: "FLOAT" },
   ]);
 });
 

--- a/src/internal/dnd-engine/__tests__/helpers.ts
+++ b/src/internal/dnd-engine/__tests__/helpers.ts
@@ -2,14 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { range } from "lodash";
-import { DndEngine } from "../engine";
-import { GridDefinition, GridTransition } from "../interfaces";
-
-export function withCommit(grid: GridDefinition, callback: (engine: DndEngine) => void): GridTransition {
-  const engine = new DndEngine(grid);
-  callback(engine);
-  return engine.commit();
-}
 
 export function forEachTimes<T>(times: number, array: T[], callback: (item: T) => void) {
   array.flatMap((item) => range(0, times).map(() => item)).forEach(callback);

--- a/src/internal/dnd-engine/engine.ts
+++ b/src/internal/dnd-engine/engine.ts
@@ -43,6 +43,10 @@ export class DndEngine {
       this.resolveConflicts(itemId);
     }
 
+    if (this.blocks.size === 0) {
+      this.refloatGrid();
+    }
+
     return this.getTransition();
   }
 
@@ -55,6 +59,10 @@ export class DndEngine {
 
     this.resolveConflicts(resize.itemId);
 
+    if (this.blocks.size === 0) {
+      this.refloatGrid();
+    }
+
     return this.getTransition();
   }
 
@@ -65,6 +73,10 @@ export class DndEngine {
 
     this.resolveConflicts(item.id);
 
+    if (this.blocks.size === 0) {
+      this.refloatGrid();
+    }
+
     return this.getTransition();
   }
 
@@ -73,22 +85,22 @@ export class DndEngine {
 
     this.grid.remove(itemId);
 
-    return this.getTransition();
-  }
-
-  commit(): GridTransition {
     if (this.blocks.size === 0) {
       this.refloatGrid();
     }
 
-    const transitionWithRefloat = this.getTransition();
+    return this.getTransition();
+  }
+
+  commit(): GridTransition {
+    const transition = this.getTransition();
 
     if (this.blocks.size === 0) {
-      this.lastCommit = transitionWithRefloat.end;
+      this.lastCommit = transition.end;
       this.cleanup();
     }
 
-    return transitionWithRefloat;
+    return transition;
   }
 
   getTransition(): GridTransition {

--- a/src/layout/calculations/reorder.ts
+++ b/src/layout/calculations/reorder.ts
@@ -48,14 +48,8 @@ export function createTransforms(
 export interface LayoutShift {
   path: Position[];
   hasConflicts: boolean;
-  current: {
-    moves: CommittedMove[];
-    items: readonly GridLayoutItem[];
-  };
-  committed: {
-    moves: CommittedMove[];
-    items: readonly GridLayoutItem[];
-  };
+  moves: CommittedMove[];
+  items: readonly GridLayoutItem[];
 }
 
 export function calculateShifts(
@@ -73,20 +67,20 @@ export function calculateShifts(
     return {
       path: newPath,
       hasConflicts: false,
-      current: { moves: [], items: grid },
-      committed: { moves: [], items: grid },
+      moves: [],
+      items: grid,
     };
   }
 
   const engine = new DndEngine({ items: grid, width: columns });
-  const moveTransition = engine.move({ itemId: activeId, path: newPath.slice(1) });
-  const commitTransition = engine.commit();
+  engine.move({ itemId: activeId, path: newPath.slice(1) });
+  const transition = engine.commit();
 
   return {
     path: newPath,
-    hasConflicts: moveTransition.blocks.length > 0,
-    current: { moves: moveTransition.moves, items: moveTransition.end.items },
-    committed: { moves: commitTransition.moves, items: commitTransition.end.items },
+    hasConflicts: transition.blocks.length > 0,
+    moves: transition.moves,
+    items: transition.end.items,
   };
 }
 

--- a/src/layout/internal.tsx
+++ b/src/layout/internal.tsx
@@ -50,7 +50,7 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange }:
     );
     pathRef.current = layoutShift.path;
     const cellRect = droppables[0][1].getBoundingClientRect();
-    setTransforms(createTransforms(content, layoutShift.current.moves, cellRect));
+    setTransforms(createTransforms(content, layoutShift.moves, cellRect));
   });
   useDragSubscription("drop", ({ active, activeId, droppables }) => {
     const collisionsIds = getCollisions(active, droppables);
@@ -63,32 +63,23 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange }:
     );
 
     // Logs for dnd-engine debugging.
-    console.log("Current grid:");
-    console.log(engineToString({ items: layoutShift.current.items, width: columns }));
+    console.log("Grid before move:");
+    console.log(engineToString({ items: content, width: columns }));
 
-    console.log("Committed grid:");
-    console.log(engineToString({ items: layoutShift.committed.items, width: columns }));
+    console.log("Grid after move:");
+    console.log(engineToString({ items: layoutShift.items, width: columns }));
 
     console.log("Layout shift:");
     console.log(layoutShift);
 
-    // Create extra transforms for "float" moves.
-    if (!layoutShift.hasConflicts) {
-      const cellRect = droppables[0][1].getBoundingClientRect();
-      setTransforms(createTransforms(content, layoutShift.committed.moves, cellRect));
-    } else {
-      setTransforms({});
-    }
+    setTransforms({});
     setActiveDragGhost(false);
     setCollisionIds(null);
     pathRef.current = [];
 
     // Commit new layout.
     if (!layoutShift.hasConflicts) {
-      setTimeout(() => {
-        onItemsChange(createCustomEvent({ items: exportLayout(layoutShift.committed.items, items) }));
-        setTransforms({});
-      }, 250);
+      onItemsChange(createCustomEvent({ items: exportLayout(layoutShift.items, items) }));
     }
   });
 


### PR DESCRIPTION
### Description

Now grid items float to top after every d&d action (move, insert, remove, resize) and not after commit. That simplifies the integration and contributes to UX.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
