### PR TITLE
Added support for touch devices

### DIFF
--- a/src/internal/dnd-controller/index.ts
+++ b/src/internal/dnd-controller/index.ts
@@ -4,9 +4,6 @@ import { Ref, RefObject, useEffect, useRef } from "react";
 import { Coordinates, DashboardItemBase } from "../interfaces";
 import { EventEmitter } from "./event-emitter";
 
-// TODO: check if D&D work in touch devices.
-// We might want to separately support mousedown+mousemove+mousedown and touchsstart+touchmove+touchend.
-
 export interface DragAndDropData extends DragDetail {
   droppables: readonly [string, HTMLElement][];
   coordinates: Coordinates;
@@ -29,10 +26,11 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
   private activeDragDetail: DragDetail | null = null;
 
   public activateDrag(dragDetail: DragDetail, coordinates: Coordinates) {
+    console.log("ACTIVATE");
     this.activeDragDetail = dragDetail;
     this.emit("start", { ...this.activeDragDetail, coordinates, droppables: [...this.droppables.entries()] });
-    document.addEventListener("mousemove", this.onMouseMove);
-    document.addEventListener("mouseup", this.onMouseUp);
+    document.addEventListener("pointermove", this.onPointerMove);
+    document.addEventListener("pointerup", this.onPointerUp);
   }
 
   public addDroppable(element: HTMLElement, id: string) {
@@ -43,20 +41,22 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
     this.droppables.delete(id);
   }
 
-  private onMouseMove = (coordinates: Coordinates) => {
+  private onPointerMove = (coordinates: Coordinates) => {
+    console.log("MOVE");
     if (!this.activeDragDetail) {
       throw new Error("Invariant violation: no active drag detail present for move.");
     }
     this.emit("move", { ...this.activeDragDetail, coordinates, droppables: [...this.droppables.entries()] });
   };
 
-  private onMouseUp = (coordinates: Coordinates) => {
+  private onPointerUp = (coordinates: Coordinates) => {
+    console.log("STOP");
     if (!this.activeDragDetail) {
       throw new Error("Invariant violation: no active drag detail present for drop.");
     }
     this.emit("drop", { ...this.activeDragDetail, coordinates, droppables: [...this.droppables.entries()] });
-    document.removeEventListener("mousemove", this.onMouseMove);
-    document.removeEventListener("mouseup", this.onMouseUp);
+    document.removeEventListener("pointermove", this.onPointerMove);
+    document.removeEventListener("pointerup", this.onPointerUp);
     this.activeDragDetail = null;
   };
 }

--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,19 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ForwardedRef, MouseEvent, forwardRef } from "react";
+import { ForwardedRef, forwardRef } from "react";
 
 import Handle from "../handle";
+import { Coordinates } from "../interfaces";
 import DragHandleIcon from "./icon";
 import styles from "./styles.css.js";
 
 export interface DragHandleProps {
   ariaLabel?: string;
-  onMouseDown: (event: MouseEvent) => void;
+  onPointerDown: (coordinates: Coordinates) => void;
 }
 
-function DragHandle({ ariaLabel, onMouseDown }: DragHandleProps, ref: ForwardedRef<HTMLButtonElement>) {
+function DragHandle({ ariaLabel, onPointerDown }: DragHandleProps, ref: ForwardedRef<HTMLButtonElement>) {
   return (
-    <Handle className={styles.handle} ref={ref} aria-label={ariaLabel} onMouseDown={onMouseDown}>
+    <Handle
+      className={styles.handle}
+      ref={ref}
+      aria-label={ariaLabel}
+      onPointerDown={(event) => onPointerDown({ pageX: event.pageX, pageY: event.pageY })}
+    >
       <DragHandleIcon />
     </Handle>
   );

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,18 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { MouseEvent } from "react";
 import Handle from "../handle";
+import { Coordinates } from "../interfaces";
 import { ResizeHandleIcon } from "./icon";
 import styles from "./styles.css.js";
 
 export interface ResizeHandleProps {
   ariaLabel: string | undefined;
-  onResize: (event: MouseEvent) => void;
+  onPointerDown: (coordinates: Coordinates) => void;
 }
 
-export default function ResizeHandle({ ariaLabel, onResize }: ResizeHandleProps) {
+export default function ResizeHandle({ ariaLabel, onPointerDown }: ResizeHandleProps) {
   return (
-    <Handle className={styles.handle} aria-label={ariaLabel} onMouseDown={onResize}>
+    <Handle
+      className={styles.handle}
+      aria-label={ariaLabel}
+      onPointerDown={(event) => onPointerDown({ pageX: event.pageX, pageY: event.pageY })}
+    >
       <ResizeHandleIcon />
     </Handle>
   );

--- a/src/item/index.tsx
+++ b/src/item/index.tsx
@@ -96,8 +96,8 @@ export default function DashboardItem({
           <WidgetContainerHeader
             handle={
               <DragHandle
-                onMouseDown={(event) => dragApi.onStart({ pageX: event.pageX, pageY: event.pageY })}
                 ariaLabel={i18nStrings.dragHandleLabel}
+                onPointerDown={(coordinates) => dragApi.onStart(coordinates)}
               />
             }
             settings={settings}
@@ -112,7 +112,7 @@ export default function DashboardItem({
         <div className={styles.resizer}>
           <ResizeHandle
             ariaLabel={i18nStrings.resizeLabel}
-            onResize={(event) => resizeApi.onStart({ pageX: event.pageX, pageY: event.pageY })}
+            onPointerDown={(coordinates) => resizeApi.onStart(coordinates)}
           />
         </div>
       )}

--- a/src/item/styles.scss
+++ b/src/item/styles.scss
@@ -35,6 +35,7 @@
 }
 
 .wrapper {
+  touch-action: none;
   position: relative;
   height: 100%;
   display: grid;


### PR DESCRIPTION
### Description

Replaced mousedown+mousemove+mouseup with pointerdown+pointermove+pointerup.

Set touch-events to none for dashboard item to prevent browsers from cancelling pointermove.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
