### PR TITLE
Make resize operation properly incremental

### DIFF
--- a/src/internal/layout-engine/__tests__/engine-float.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-float.test.ts
@@ -53,10 +53,10 @@ test("float creates addition moves", () => {
   ]);
   const layoutShift = new LayoutEngine(grid).move(fromTextPath("C2 B2 A2", grid)).refloat().getLayoutShift();
   expect(layoutShift.moves).toEqual([
-    { itemId: "E", y: 1, x: 1, type: "USER" },
-    { itemId: "E", y: 1, x: 0, type: "USER" },
-    { itemId: "F", y: 1, x: 2, type: "FLOAT" },
-    { itemId: "G", y: 1, x: 3, type: "FLOAT" },
-    { itemId: "H", y: 2, x: 2, type: "FLOAT" },
+    { itemId: "E", y: 1, x: 1, width: 2, height: 1, type: "USER" },
+    { itemId: "E", y: 1, x: 0, width: 2, height: 1, type: "USER" },
+    { itemId: "F", y: 1, x: 2, width: 1, height: 1, type: "FLOAT" },
+    { itemId: "G", y: 1, x: 3, width: 1, height: 1, type: "FLOAT" },
+    { itemId: "H", y: 2, x: 2, width: 1, height: 1, type: "FLOAT" },
   ]);
 });

--- a/src/internal/layout-engine/__tests__/engine-move-larger.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-move-larger.test.ts
@@ -427,7 +427,7 @@ describe("empty spaces are prioritized over disturbing other items", () => {
 describe("multiple overlap resolutions", () => {
   test.each([
     [
-      "G forces B and C to resolve twice",
+      "G forces C to resolve twice",
       [
         ["A", "A", " ", "F"],
         ["E", "B", "B", "F"],
@@ -438,10 +438,10 @@ describe("multiple overlap resolutions", () => {
       ],
       "A3 B3 B2 C2",
       [
-        [" ", "C", " ", "F"],
+        [" ", "C", "A", "A"],
         ["E", "C", "G", "F"],
-        ["A", "A", "B", "B"],
-        ["H", " ", "B", "B"],
+        [" ", "B", "B", "F"],
+        ["H", "B", "B", " "],
         [" ", " ", " ", " "],
         [" ", " ", "D", " "],
       ],
@@ -449,7 +449,7 @@ describe("multiple overlap resolutions", () => {
   ])("%s", (_, gridMatrix, path, expectation) => {
     const grid = fromMatrix(gridMatrix);
     const layoutShift = new LayoutEngine(grid).move(fromTextPath(path, grid)).getLayoutShift();
-    const moveIds = layoutShift.moves.map((move) => move.itemId);
+    const moveIds = layoutShift.moves.filter((move) => move.type !== "USER").map((move) => move.itemId);
     expect(toString(layoutShift.next)).toBe(toString(expectation));
     expect(new Set(moveIds).size).toBeLessThan(moveIds.length);
   });

--- a/src/internal/layout-engine/__tests__/engine-resize.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-resize.test.ts
@@ -11,7 +11,7 @@ test("decrease in element size never creates conflicts", () => {
     const grid = generateGrid(...args);
     const resize = generateResize(grid, { maxWidthIncrement: 0, maxHeightIncrement: 0 });
     const layoutShift = new LayoutEngine(grid).resize(resize).refloat().getLayoutShift();
-    expect(layoutShift.moves.filter((move) => move.type !== "FLOAT")).toHaveLength(0);
+    expect(layoutShift.moves.filter((move) => move.type !== "FLOAT" && move.type !== "RESIZE")).toHaveLength(0);
   });
 });
 
@@ -36,7 +36,8 @@ test("commits no changes if resize path returns to original or smaller", () => {
         y: randomPathValue(resizeTarget.y + resizeTarget.height),
       };
       resize.path = [...resize.path, ...generateRandomPath(lastPathItem, originalSizePath)];
-      expect(new LayoutEngine(grid).resize(resize).getLayoutShift().moves).toHaveLength(0);
+      const moves = new LayoutEngine(grid).resize(resize).getLayoutShift().moves;
+      expect(moves.filter((move) => move.type !== "RESIZE")).toHaveLength(0);
     }
   });
 
@@ -47,6 +48,46 @@ test("commits no changes if resize path returns to original or smaller", () => {
 
 describe("resize scenarios", () => {
   test.each([
+    [
+      "resize A 2:1 -> 2:2",
+      [
+        ["A", "B", " "],
+        ["D", "C", " "],
+        [" ", " ", " "],
+      ],
+      {
+        itemId: "A",
+        path: [
+          { x: 2, y: 1 },
+          { x: 2, y: 2 },
+        ],
+      },
+      [
+        ["A", "A", "B"],
+        ["A", "A", " "],
+        ["D", "C", " "],
+      ],
+    ],
+    [
+      "resize A 1:2 -> 2:2",
+      [
+        ["A", "B", " "],
+        ["D", "C", " "],
+        [" ", " ", " "],
+      ],
+      {
+        itemId: "A",
+        path: [
+          { x: 1, y: 2 },
+          { x: 2, y: 2 },
+        ],
+      },
+      [
+        ["A", "A", "B"],
+        ["A", "A", "C"],
+        ["D", " ", " "],
+      ],
+    ],
     [
       "resize A to 3:1",
       [

--- a/src/internal/layout-engine/__tests__/engine-validation.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-validation.test.ts
@@ -145,9 +145,9 @@ test("normalizes move path and continues when from the repeating position", () =
   const grid = fromMatrix([[" ", "A", " "]]);
   const layoutShift = new LayoutEngine(grid).move(fromTextPath("B1 B2 B3 B2 B3 B4", grid)).getLayoutShift();
   expect(layoutShift.moves).toEqual([
-    { itemId: "A", x: 1, y: 1, type: "USER" },
-    { itemId: "A", x: 1, y: 2, type: "USER" },
-    { itemId: "A", x: 1, y: 3, type: "USER" },
+    { itemId: "A", x: 1, y: 1, width: 1, height: 1, type: "USER" },
+    { itemId: "A", x: 1, y: 2, width: 1, height: 1, type: "USER" },
+    { itemId: "A", x: 1, y: 3, width: 1, height: 1, type: "USER" },
   ]);
 });
 
@@ -159,7 +159,7 @@ test("normalizes move path when it has missing steps", () => {
   ]);
   const layoutShift = new LayoutEngine(grid).move(fromTextPath("A1 B2", grid)).getLayoutShift();
   expect(layoutShift.moves).toEqual([
-    { itemId: "A", x: 1, y: 0, type: "USER" },
-    { itemId: "A", x: 1, y: 1, type: "USER" },
+    { itemId: "A", x: 1, y: 0, width: 1, height: 1, type: "USER" },
+    { itemId: "A", x: 1, y: 1, width: 1, height: 1, type: "USER" },
   ]);
 });

--- a/src/internal/layout-engine/interfaces.ts
+++ b/src/internal/layout-engine/interfaces.ts
@@ -17,7 +17,9 @@ export interface CommittedMove {
   itemId: ItemId;
   x: number;
   y: number;
-  type: "USER" | "VACANT" | "PRIORITY" | "ESCAPE" | "FLOAT";
+  width: number;
+  height: number;
+  type: "USER" | "VACANT" | "PRIORITY" | "ESCAPE" | "FLOAT" | "RESIZE";
 }
 
 export interface LayoutShift {


### PR DESCRIPTION
### Description

Added support for the following case:

Resize right, bottom:

```
['A', 'B', ' ']    ['A', 'A', 'B']    ['A', 'A', 'B']
['C', 'D', ' '] -> ['C', 'D', ' '] -> ['A', 'A', ' ']
[' ', ' ', ' ']    [' ', ' ', ' ']    ['C', 'D', ' ']
```

Resize bottom, right:

```
['A', 'B', ' ']    ['A', 'B', ' ']    ['A', 'A', 'B']
['C', 'D', ' '] -> ['A', 'D', ' '] -> ['A', 'A', 'D']
[' ', ' ', ' ']    ['C', ' ', ' ']    ['C', ' ', ' ']
```

Demo:

https://user-images.githubusercontent.com/20790937/205298054-767fcaa8-85e4-4ab2-991c-dd0a12a78856.mov


### How has this been tested?

Added new unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
