### PR TITLE
Fixed console errors caused by invalid chart height on first render

### DIFF
--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -130,7 +130,7 @@ export const demoWidgets: Record<string, { data: ItemData; definition?: PaletteP
             {() => (
               <TwoColContainer
                 left={
-                  <QueryContainer>
+                  <QueryContainer minHeight={200}>
                     {({ height = 0 }) => (
                       <SpaceBetween size="xs">
                         <Box fontSize="heading-s" fontWeight="bold">


### PR DESCRIPTION
### Description

When minHeight is not set the query container size can be 0 causing the chart height to be less than zero and cause an error.

### How has this been tested?

Manual

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
