### PR TITLE
Keyboard items reorder

### DIFF
--- a/src/item/index.tsx
+++ b/src/item/index.tsx
@@ -106,13 +106,13 @@ export default function DashboardItem({
       draggableApi.startMove(coordiantes, "manual");
       setInteractionType("manual");
     } else {
-      onKeyboardTransitionDiscard();
+      draggableApi.endTransition();
     }
   }
 
   function onKeyboardTransitionDiscard() {
     if (transition) {
-      draggableApi.endTransition();
+      draggableApi.cancelTransition();
     }
   }
 

--- a/src/layout/internal.tsx
+++ b/src/layout/internal.tsx
@@ -155,6 +155,10 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange, e
     setTransitionDelayed.cancel();
     setTransition(null);
 
+    if (detail.cancel) {
+      return;
+    }
+
     const itemWidth = transition.layoutItem
       ? transition.layoutItem.width
       : transition.draggableItem.definition.defaultColumnSpan;

--- a/test/dnd/keyboard-interactions.test.ts
+++ b/test/dnd/keyboard-interactions.test.ts
@@ -2,13 +2,51 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import useBrowser from "@cloudscape-design/browser-test-tools/use-browser";
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import dragHandleStyles from "../../lib/components/internal/drag-handle/styles.selectors.js";
+import layoutItemStyles from "../../lib/components/item/styles.selectors.js";
+import layoutStyles from "../../lib/components/layout/styles.selectors.js";
 
-function setupTest(url: string, testFn: (page: ScreenshotPageObject, browser: WebdriverIO.Browser) => Promise<void>) {
+class DndPageObject extends ScreenshotPageObject {
+  sleep(time = 200) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+  }
+
+  async getHeaders() {
+    const items = await this.browser.$$(`.${layoutStyles.default.root} .${layoutItemStyles.default.header}`);
+    const headers = await Promise.all([...items].map((item) => item.getText()));
+
+    const columns = 4;
+    const rows = Math.floor(headers.length / columns);
+    const grid: string[][] = [...new Array(rows)].map(() => [...new Array(columns)]);
+
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < columns; col++) {
+        grid[row][col] = headers[row * columns + col]?.slice("Widget ".length) ?? " ";
+      }
+    }
+
+    return grid;
+  }
+
+  async clickDragHandle(id: string) {
+    await this.click(`[data-item-id="${id}"] .${dragHandleStyles.default.handle}`);
+  }
+
+  async focusDragHandle(id: string) {
+    await this.clickDragHandle(id);
+    await this.keys(["Enter"]);
+  }
+
+  isDragHandleFocused(id: string) {
+    return this.isFocused(`[data-item-id="${id}"] .${dragHandleStyles.default.handle}`);
+  }
+}
+
+function setupTest(url: string, testFn: (page: DndPageObject, browser: WebdriverIO.Browser) => Promise<void>) {
   return useBrowser(async (browser) => {
     await browser.url(url);
-    const page = new ScreenshotPageObject(browser);
+    const page = new DndPageObject(browser);
     await page.waitForVisible("main");
     await testFn(page, browser);
   });
@@ -17,51 +55,82 @@ function setupTest(url: string, testFn: (page: ScreenshotPageObject, browser: We
 test(
   "navigates items in the palette",
   setupTest("/index.html#/dnd/engine-a2p-test", async (page) => {
-    const handleQ = `[data-item-id="Q"] .${dragHandleStyles.default.handle}`;
-    const handleR = `[data-item-id="R"] .${dragHandleStyles.default.handle}`;
-    const handleS = `[data-item-id="S"] .${dragHandleStyles.default.handle}`;
-
-    await page.click(handleR);
+    await page.clickDragHandle("R");
     await page.keys(["ArrowRight"]);
-    await expect(page.isFocused(handleS)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("S")).resolves.toBe(true);
 
-    await page.click(handleR);
+    await page.clickDragHandle("R");
     await page.keys(["ArrowDown"]);
-    await expect(page.isFocused(handleS)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("S")).resolves.toBe(true);
 
-    await page.click(handleR);
+    await page.clickDragHandle("R");
     await page.keys(["ArrowLeft"]);
-    await expect(page.isFocused(handleQ)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("Q")).resolves.toBe(true);
 
-    await page.click(handleR);
+    await page.clickDragHandle("R");
     await page.keys(["ArrowUp"]);
-    await expect(page.isFocused(handleQ)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("Q")).resolves.toBe(true);
   })
 );
 
 test(
   "navigates items in the dashboard",
   setupTest("/index.html#/dnd/engine-a2p-test", async (page) => {
-    const handleB = `[data-item-id="B"] .${dragHandleStyles.default.handle}`;
-    const handleE = `[data-item-id="E"] .${dragHandleStyles.default.handle}`;
-    const handleF = `[data-item-id="F"] .${dragHandleStyles.default.handle}`;
-    const handleG = `[data-item-id="G"] .${dragHandleStyles.default.handle}`;
-    const handleJ = `[data-item-id="J"] .${dragHandleStyles.default.handle}`;
-
-    await page.click(handleF);
+    await page.clickDragHandle("F");
     await page.keys(["ArrowLeft"]);
-    await expect(page.isFocused(handleE)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("E")).resolves.toBe(true);
 
-    await page.click(handleF);
+    await page.clickDragHandle("F");
     await page.keys(["ArrowRight"]);
-    await expect(page.isFocused(handleG)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("G")).resolves.toBe(true);
 
-    await page.click(handleF);
+    await page.clickDragHandle("F");
     await page.keys(["ArrowUp"]);
-    await expect(page.isFocused(handleB)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("B")).resolves.toBe(true);
 
-    await page.click(handleF);
+    await page.clickDragHandle("F");
     await page.keys(["ArrowDown"]);
-    await expect(page.isFocused(handleJ)).resolves.toBe(true);
+    await expect(page.isDragHandleFocused("J")).resolves.toBe(true);
   })
 );
+
+describe("items reordered with keyboard", () => {
+  test(
+    "item move can be submitted",
+    setupTest("/index.html#/dnd/engine-a2h-test", async (page) => {
+      await page.focusDragHandle("A");
+      await page.keys(["ArrowRight"]);
+      await page.sleep();
+      await page.keys(["ArrowRight"]);
+      await page.sleep();
+      await page.keys(["ArrowDown"]);
+      await page.sleep();
+      await page.keys(["ArrowLeft"]);
+      await page.sleep();
+      await page.keys(["ArrowUp"]);
+      await page.sleep();
+      await page.keys(["Enter"]);
+
+      await expect(page.getHeaders()).resolves.toEqual([
+        ["B", "A", "C", "D"],
+        ["E", "F", "G", "H"],
+      ]);
+    })
+  );
+
+  test(
+    "item move can be discarded",
+    setupTest("/index.html#/dnd/engine-a2h-test", async (page) => {
+      await page.focusDragHandle("F");
+      await page.keys(["ArrowUp"]);
+      await page.sleep();
+      await page.keys(["Escape"]);
+      await page.sleep();
+
+      await expect(page.getHeaders()).resolves.toEqual([
+        ["A", "B", "C", "D"],
+        ["E", "F", "G", "H"],
+      ]);
+    })
+  );
+});

--- a/test/dnd/mouse-interactions.test.ts
+++ b/test/dnd/mouse-interactions.test.ts
@@ -25,8 +25,7 @@ test(
     const placeholderH = await browser.$('[data-item-id="H"]');
     await handleG.dragAndDrop(placeholderH);
 
-    const pngString = await page.fullPageScreenshot();
-    expect(pngString).toMatchImageSnapshot();
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })
 );
 
@@ -40,8 +39,7 @@ test(
     const placeholderH = await browser.$('[data-item-id="H"]');
     await handleG.dragAndDrop(placeholderH);
 
-    const pngString = await page.fullPageScreenshot();
-    expect(pngString).toMatchImageSnapshot();
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })
 );
 


### PR DESCRIPTION
### Description

Items can be reordered with keyboard.

Demo:

https://user-images.githubusercontent.com/20790937/206194663-6c69dfde-da20-4b46-b1d3-f4d53878ec2a.mov

### How has this been tested?

New e2e tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
