### PR TITLE
Items resizeable with keyboard

### DIFF
--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ForwardedRef, KeyboardEvent, forwardRef } from "react";
-
+import { KeyboardEvent } from "react";
 import Handle from "../handle";
 import { Coordinates } from "../interfaces";
 import { getCoordinates } from "../utils/get-coordinates";
@@ -14,11 +13,10 @@ export interface DragHandleProps {
   onKeyDown: (event: KeyboardEvent) => void;
 }
 
-function DragHandle({ ariaLabel, onPointerDown, onKeyDown }: DragHandleProps, ref: ForwardedRef<HTMLButtonElement>) {
+export default function DragHandle({ ariaLabel, onPointerDown, onKeyDown }: DragHandleProps) {
   return (
     <Handle
       className={styles.handle}
-      ref={ref}
       aria-label={ariaLabel}
       onPointerDown={(event) => onPointerDown(getCoordinates(event))}
       onKeyDown={onKeyDown}
@@ -27,5 +25,3 @@ function DragHandle({ ariaLabel, onPointerDown, onKeyDown }: DragHandleProps, re
     </Handle>
   );
 }
-
-export default forwardRef(DragHandle);

--- a/src/internal/item-context.ts
+++ b/src/internal/item-context.ts
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Transform } from "@dnd-kit/utilities";
 import { createContext, useContext } from "react";
-import { DashboardItemBase, Direction, Position } from "./interfaces";
+import { DashboardItemBase, Direction } from "./interfaces";
 
 export interface ItemContext {
   item: DashboardItemBase<unknown>;
   itemSize: { width: number; height: number };
-  transform: null | Position;
+  itemMaxSize: { width: number; height: number };
+  transform: null | Transform;
   onNavigate(direction: Direction): void;
 }
 

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { KeyboardEvent } from "react";
 import Handle from "../handle";
 import { Coordinates } from "../interfaces";
 import { getCoordinates } from "../utils/get-coordinates";
@@ -9,14 +10,16 @@ import styles from "./styles.css.js";
 export interface ResizeHandleProps {
   ariaLabel: string | undefined;
   onPointerDown: (coordinates: Coordinates) => void;
+  onKeyDown: (event: KeyboardEvent) => void;
 }
 
-export default function ResizeHandle({ ariaLabel, onPointerDown }: ResizeHandleProps) {
+export default function ResizeHandle({ ariaLabel, onPointerDown, onKeyDown }: ResizeHandleProps) {
   return (
     <Handle
       className={styles.handle}
       aria-label={ariaLabel}
       onPointerDown={(event) => onPointerDown(getCoordinates(event))}
+      onKeyDown={onKeyDown}
     >
       <ResizeHandleIcon />
     </Handle>

--- a/src/item/__tests__/dashboard-item.test.tsx
+++ b/src/item/__tests__/dashboard-item.test.tsx
@@ -25,6 +25,7 @@ function render(jsx: ReactElement) {
             value={{
               item: { id: "1", definition: { defaultColumnSpan: 1, defaultRowSpan: 1 }, data: null },
               itemSize: { width: 1, height: 1 },
+              itemMaxSize: { width: 1, height: 1 },
               transform: null,
               onNavigate: () => undefined,
             }}

--- a/src/layout/calculations/shift-layout.ts
+++ b/src/layout/calculations/shift-layout.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Transform } from "@dnd-kit/utilities";
 import { toString as engineToString } from "../../internal/debug-tools";
 import { GridLayout, ItemId } from "../../internal/interfaces";
 import { Position, Rect } from "../../internal/interfaces";
@@ -18,14 +19,19 @@ export function printLayoutDebug(grid: GridLayout, layoutShift: LayoutShift) {
 }
 
 export function createTransforms(grid: GridLayout, moves: readonly CommittedMove[]) {
-  const transforms: Record<ItemId, Position> = {};
+  const transforms: Record<ItemId, Transform> = {};
 
   for (const move of moves) {
     const item = grid.items.find((prev) => prev.id === move.itemId);
 
     // Item can be missing if inserting.
     if (item) {
-      transforms[item.id] = { x: move.x - item.x, y: move.y - item.y };
+      transforms[item.id] = {
+        x: move.x - item.x,
+        y: move.y - item.y,
+        scaleX: move.width,
+        scaleY: move.height,
+      };
     }
   }
 

--- a/src/palette/internal.tsx
+++ b/src/palette/internal.tsx
@@ -53,6 +53,7 @@ export default function DashboardPalette<D>({ items, renderItem }: DashboardPale
             value={{
               item,
               itemSize: { width: item.definition.defaultColumnSpan, height: item.definition.defaultRowSpan },
+              itemMaxSize: { width: item.definition.defaultColumnSpan, height: item.definition.defaultRowSpan },
               transform: null,
               onNavigate: (direction) => onItemNavigate(index, direction),
             }}

--- a/test/dnd/dnd-page-object.ts
+++ b/test/dnd/dnd-page-object.ts
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+import dragHandleStyles from "../../lib/components/internal/drag-handle/styles.selectors.js";
+import resizeHandleStyles from "../../lib/components/internal/resize-handle/styles.selectors.js";
+import layoutItemStyles from "../../lib/components/item/styles.selectors.js";
+import layoutStyles from "../../lib/components/layout/styles.selectors.js";
+
+export class DndPageObject extends ScreenshotPageObject {
+  sleep(time = 200) {
+    return new Promise((resolve) => setTimeout(resolve, time));
+  }
+
+  async getHeaders() {
+    const items = await this.browser.$$(`.${layoutStyles.default.root} .${layoutItemStyles.default.header}`);
+    const headers = await Promise.all([...items].map((item) => item.getText()));
+
+    const columns = 4;
+    const rows = Math.floor(headers.length / columns);
+    const grid: string[][] = [...new Array(rows)].map(() => [...new Array(columns)]);
+
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < columns; col++) {
+        grid[row][col] = headers[row * columns + col]?.slice("Widget ".length) ?? " ";
+      }
+    }
+
+    return grid;
+  }
+
+  async clickDragHandle(id: string) {
+    await this.click(`[data-item-id="${id}"] .${dragHandleStyles.default.handle}`);
+  }
+
+  async focusDragHandle(id: string) {
+    await this.clickDragHandle(id);
+    await this.keys(["Enter"]);
+  }
+
+  async focusResizeHandle(id: string) {
+    await this.click(`[data-item-id="${id}"] .${resizeHandleStyles.default.handle}`);
+    await this.keys(["Enter"]);
+  }
+
+  isDragHandleFocused(id: string) {
+    return this.isFocused(`[data-item-id="${id}"] .${dragHandleStyles.default.handle}`);
+  }
+
+  async getItemSize(id: string) {
+    return (await this.browser.$(`[data-item-id="${id}"]`)).getSize();
+  }
+}

--- a/test/dnd/mouse-interactions.test.ts
+++ b/test/dnd/mouse-interactions.test.ts
@@ -16,28 +16,26 @@ function setupTest(url: string, testFn: (page: ScreenshotPageObject, browser: We
 }
 
 test(
-  "items reorder works when page is scrolled",
+  "items reorder with pointer",
   setupTest("/index.html#/dnd/engine-a2h-test", async (page, browser) => {
-    await page.setWindowSize({ width: 800, height: 1000 });
-    await page.windowScrollTo({ left: 0, top: 700 });
+    await page.setWindowSize({ width: 1200, height: 800 });
 
-    const handleG = await browser.$(`[data-item-id="G"] .${dragHandleStyles.default.handle}`);
-    const placeholderH = await browser.$('[data-item-id="H"]');
-    await handleG.dragAndDrop(placeholderH);
+    const handleA = await browser.$(`[data-item-id="A"] .${dragHandleStyles.default.handle}`);
+    const placeholderB = await browser.$('[data-item-id="B"]');
+    await handleA.dragAndDrop(placeholderB);
 
     expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })
 );
 
 test(
-  "items resize works when page is scrolled",
+  "items resize with pointer",
   setupTest("/index.html#/dnd/engine-a2h-test", async (page, browser) => {
-    await page.setWindowSize({ width: 800, height: 1000 });
-    await page.windowScrollTo({ left: 0, top: 700 });
+    await page.setWindowSize({ width: 1200, height: 800 });
 
-    const handleG = await browser.$(`[data-item-id="G"] .${resizeHandleStyles.default.handle}`);
-    const placeholderH = await browser.$('[data-item-id="H"]');
-    await handleG.dragAndDrop(placeholderH);
+    const handleA = await browser.$(`[data-item-id="A"] .${resizeHandleStyles.default.handle}`);
+    const placeholderB = await browser.$('[data-item-id="B"]');
+    await handleA.dragAndDrop(placeholderB);
 
     expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })


### PR DESCRIPTION
### Description

Items can be resized with keyboard.

Demo:

https://user-images.githubusercontent.com/20790937/206224988-27c0f21f-e73b-4824-bfe4-07e9fb76e689.mov


### How has this been tested?

New e2e tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
