### PR TITLE
Item resize with keyboard now has correct size at all steps

### DIFF
--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -41,7 +41,7 @@ const createDefaultWidget = (id: string) => ({
 
 export const demoWidgets: ItemWidgets = {
   D: {
-    definition: { defaultColumnSpan: 2, defaultRowSpan: 1, minColumnSpan: 2, minRowSpan: 1 },
+    definition: { defaultColumnSpan: 2, defaultRowSpan: 1 },
     data: {
       title: "Demo widget",
       description: "Most minimal widget",
@@ -226,15 +226,15 @@ export const demoPaletteItems: readonly PaletteProps.Item<ItemData>[] = Object.e
 
 export const letterWidgets = [..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"].reduce((acc, letter) => {
   const definitions: { [letter: string]: DashboardItemDefinition } = {
-    R: { defaultRowSpan: 1, defaultColumnSpan: 2 },
-    S: { defaultRowSpan: 1, defaultColumnSpan: 2 },
-    T: { defaultRowSpan: 1, defaultColumnSpan: 2 },
-    U: { defaultRowSpan: 2, defaultColumnSpan: 1 },
-    V: { defaultRowSpan: 2, defaultColumnSpan: 1 },
-    W: { defaultRowSpan: 2, defaultColumnSpan: 1 },
-    X: { defaultRowSpan: 2, defaultColumnSpan: 2 },
-    Y: { defaultRowSpan: 2, defaultColumnSpan: 2 },
-    Z: { defaultRowSpan: 2, defaultColumnSpan: 2 },
+    R: { defaultRowSpan: 1, defaultColumnSpan: 2, minRowSpan: 1, minColumnSpan: 2 },
+    S: { defaultRowSpan: 1, defaultColumnSpan: 2, minRowSpan: 1, minColumnSpan: 2 },
+    T: { defaultRowSpan: 1, defaultColumnSpan: 2, minRowSpan: 1, minColumnSpan: 2 },
+    U: { defaultRowSpan: 4, defaultColumnSpan: 1, minRowSpan: 4, minColumnSpan: 1 },
+    V: { defaultRowSpan: 4, defaultColumnSpan: 1, minRowSpan: 4, minColumnSpan: 1 },
+    W: { defaultRowSpan: 4, defaultColumnSpan: 1, minRowSpan: 4, minColumnSpan: 1 },
+    X: { defaultRowSpan: 4, defaultColumnSpan: 2, minRowSpan: 4, minColumnSpan: 2 },
+    Y: { defaultRowSpan: 4, defaultColumnSpan: 2, minRowSpan: 4, minColumnSpan: 2 },
+    Z: { defaultRowSpan: 4, defaultColumnSpan: 2, minRowSpan: 4, minColumnSpan: 2 },
   };
   acc[letter] = {
     id: letter,
@@ -257,6 +257,7 @@ export function createLetterItems(grid: null | string[][], palette?: string[]) {
     fromMatrix(grid),
     Object.values(letterWidgets).map((item) => ({ ...item, columnOffset: 0, columnSpan: 0, rowSpan: 0 }))
   );
+
   const usedLetterItems = new Set(layoutItems.map((item) => item.id));
   const paletteItems = Object.values(letterWidgets).filter(
     (item) => !usedLetterItems.has(item.id) && (!palette || palette.includes(item.id))

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -6,3 +6,5 @@ export const BREAKPOINT_SMALL = 688;
 export const COLUMNS_SMALL = 1;
 
 export const COLUMNS_FULL = 4;
+
+export const MIN_ROW_SPAN = 2;

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -10,7 +10,7 @@ import styles from "./styles.css.js";
 import { zipTwoArrays } from "./utils";
 
 const GRID_GAP = 16;
-const ROWSPAN_HEIGHT = 260;
+const ROWSPAN_HEIGHT = 100;
 
 export default function Grid({ layout, children, columns, rows }: GridProps) {
   const [gridWidth, containerQueryRef] = useContainerQuery((entry) => entry.contentBoxWidth, []);

--- a/src/internal/grid/styles.scss
+++ b/src/internal/grid/styles.scss
@@ -6,7 +6,7 @@
   justify-content: stretch;
   align-content: stretch;
   gap: cs.$space-scaled-m;
-  grid-auto-rows: 260px;
+  grid-auto-rows: 100px;
 }
 
 .grid[data-columns="1"] {

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { MIN_ROW_SPAN } from "../constants";
 import { DragAndDropData, Operation, useDragSubscription, useDraggable } from "../dnd-controller/controller";
 import { useGridContext } from "../grid-context";
 import { DashboardItemBase, Direction, ItemId, Transform } from "../interfaces";
@@ -95,14 +96,17 @@ function ItemContainerComponent(
       setScroll({ x: window.scrollX, y: window.scrollY });
 
       if (operation === "resize") {
-        const { width: cellWidth, height: cellHeight } = dropTarget!.scale({ width: 1, height: 1 });
+        const { width: minWidth, height: minHeight } = dropTarget!.scale({
+          width: draggableItem.definition.minColumnSpan ?? 1,
+          height: Math.max(draggableItem.definition.minRowSpan ?? 1, MIN_ROW_SPAN),
+        });
         const { width: maxWidth } = dropTarget!.scale(itemMaxSize);
         setTransition({
           operation,
           itemId: draggableItem.id,
           sizeTransform: {
-            width: Math.max(cellWidth, Math.min(maxWidth, draggableSize.width + cursorOffset.x)),
-            height: Math.max(cellHeight, draggableSize.height + cursorOffset.y),
+            width: Math.max(minWidth, Math.min(maxWidth, draggableSize.width + cursorOffset.x)),
+            height: Math.max(minHeight, draggableSize.height + cursorOffset.y),
           },
           positionTransform: null,
         });
@@ -273,7 +277,7 @@ function ItemContainerComponent(
       return { transition: transitionStyle };
     }
 
-    const shouldTransformSize = transform.width > 1 || transform.height > 1;
+    const shouldTransformSize = transform.width !== itemSize.width || transform.height !== itemSize.height;
 
     return {
       transform: CSSUtil.Transform.toString({

--- a/src/internal/utils/__tests__/layout.test.ts
+++ b/src/internal/utils/__tests__/layout.test.ts
@@ -6,13 +6,20 @@ import { fromMatrix, toString } from "../../debug-tools";
 import { DashboardItem } from "../../interfaces";
 import { createItemsLayout, createPlaceholdersLayout, exportItemsLayout } from "../layout";
 
-function makeItem(id: string, columnOffset: number, columnSpan: number, rowSpan: number): DashboardItem<unknown> {
+function makeItem(
+  id: string,
+  columnOffset: number,
+  columnSpan: number,
+  rowSpan: number,
+  minColumnSpan = 1,
+  minRowSpan = 1
+): DashboardItem<unknown> {
   return {
     id,
     columnOffset,
     rowSpan,
     columnSpan,
-    definition: { defaultRowSpan: 1, defaultColumnSpan: 1 },
+    definition: { defaultRowSpan: 1, defaultColumnSpan: 1, minColumnSpan, minRowSpan },
     data: null,
   };
 }
@@ -31,22 +38,41 @@ describe("createItemsLayout", () => {
       2,
       [
         ["A1", "B1"],
+        ["A1", "B1"],
         ["A2", "B2"],
+        ["A2", "B2"],
+        ["A3", "B3"],
         ["A3", "B3"],
       ],
     ],
     [
-      [makeItem("A", 0, 2, 2), makeItem("B", 1, 2, 1), makeItem("C", 2, 1, 2)],
+      [makeItem("A", 0, 2, 3), makeItem("B", 1, 2, 1), makeItem("C", 2, 1, 2)],
       3,
       [
         ["A", "A", " "],
         ["A", "A", " "],
+        ["A", "A", " "],
+        [" ", "B", "B"],
         [" ", "B", "B"],
         [" ", " ", "C"],
         [" ", " ", "C"],
       ],
     ],
-    [[makeItem("A", 0, 1, 1), makeItem("B", 1, 1, 1), makeItem("C", 0, 2, 1)], 1, [["A"], ["B"], ["C"]]],
+    [
+      [makeItem("A", 0, 1, 1), makeItem("B", 1, 1, 1), makeItem("C", 0, 2, 1)],
+      1,
+      [["A"], ["A"], ["B"], ["B"], ["C"], ["C"]],
+    ],
+    [
+      [makeItem("A", 0, 1, 1, 2, 2), makeItem("B", 0, 1, 1, 3, 1)],
+      3,
+      [
+        ["A", "A", " "],
+        ["A", "A", " "],
+        ["B", "B", "B"],
+        ["B", "B", "B"],
+      ],
+    ],
   ])("Transforms dashboard items to internal grid layout", (items, columns, expectation) => {
     expect(toString(createItemsLayout(items, columns))).toBe(toString(expectation));
   });

--- a/src/internal/utils/layout.ts
+++ b/src/internal/utils/layout.ts
@@ -1,25 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { MIN_ROW_SPAN } from "../constants";
 import { DashboardItem, GridLayout, GridLayoutItem, ItemId } from "../interfaces";
 
 export function createItemsLayout(items: readonly DashboardItem<unknown>[], columns: number): GridLayout {
   const layoutItems: GridLayoutItem[] = [];
   const colAffordance = Array(columns).fill(-1);
 
-  for (const { id, columnSpan, rowSpan, columnOffset } of items) {
+  for (const { id, columnSpan, rowSpan, columnOffset, definition } of items) {
     const startCol = Math.min(columns - 1, columnOffset);
-    const allowedColSpan = Math.min(columns - startCol, columnSpan);
+    const allowedColSpan = Math.max(definition.minColumnSpan ?? 1, Math.min(columns - startCol, columnSpan));
+    const allowedRowSpan = Math.max(MIN_ROW_SPAN, definition.minRowSpan ?? 1, rowSpan);
 
     let itemRow = 0;
     for (let col = startCol; col < startCol + allowedColSpan; col++) {
       itemRow = Math.max(itemRow, colAffordance[col] + 1);
     }
 
-    layoutItems.push({ id, width: allowedColSpan, height: rowSpan, x: startCol, y: itemRow });
+    layoutItems.push({ id, width: allowedColSpan, height: allowedRowSpan, x: startCol, y: itemRow });
 
     for (let col = startCol; col < startCol + allowedColSpan; col++) {
-      colAffordance[col] = itemRow + rowSpan - 1;
+      colAffordance[col] = itemRow + allowedRowSpan - 1;
     }
   }
 

--- a/src/layout/internal.tsx
+++ b/src/layout/internal.tsx
@@ -3,7 +3,7 @@
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 import clsx from "clsx";
 import { useMemo, useRef, useState } from "react";
-import { BREAKPOINT_SMALL, COLUMNS_FULL, COLUMNS_SMALL } from "../internal/constants";
+import { BREAKPOINT_SMALL, COLUMNS_FULL, COLUMNS_SMALL, MIN_ROW_SPAN } from "../internal/constants";
 import { Operation, useDragSubscription } from "../internal/dnd-controller/controller";
 import Grid from "../internal/grid";
 import { DashboardItem, DashboardItemBase, Direction, GridLayoutItem, ItemId } from "../internal/interfaces";
@@ -74,7 +74,13 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange, e
   if (transition) {
     const layout = transition.layoutShift?.next ?? itemsLayout;
     const layoutItem = layout.items.find((it) => it.id === transition.draggableItem.id);
-    const itemHeight = layoutItem?.height ?? transition.draggableItem.definition.defaultRowSpan;
+    const itemHeight =
+      layoutItem?.height ??
+      Math.max(
+        MIN_ROW_SPAN,
+        transition.draggableItem.definition.minRowSpan ?? 1,
+        transition.draggableItem.definition.defaultRowSpan
+      );
 
     // Add extra row for resize when already at the bottom.
     if (transition.operation === "resize") {
@@ -197,7 +203,11 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange, e
 
   function shiftItemLeft(transition: Transition) {
     const lastPosition = transition.path[transition.path.length - 1];
-    if (lastPosition.x > (transition.operation === "resize" ? 1 : 0)) {
+    const layout = transition.layoutShift?.next ?? itemsLayout;
+    const layoutItem = layout.items.find((it) => it.id === transition.draggableItem.id);
+    const position = layoutItem?.x ?? 0;
+    const minSize = Math.max(1, transition.draggableItem.definition.minColumnSpan ?? 1);
+    if (lastPosition.x > (transition.operation === "resize" ? position + minSize : 0)) {
       updateManualItemTransition(transition, [
         ...transition.path,
         new Position({ x: lastPosition.x - 1, y: lastPosition.y }),
@@ -221,7 +231,11 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange, e
 
   function shiftItemUp(transition: Transition) {
     const lastPosition = transition.path[transition.path.length - 1];
-    if (lastPosition.y > (transition.operation === "resize" ? 1 : 0)) {
+    const layout = transition.layoutShift?.next ?? itemsLayout;
+    const layoutItem = layout.items.find((it) => it.id === transition.draggableItem.id);
+    const position = layoutItem?.y ?? 0;
+    const minSize = Math.max(MIN_ROW_SPAN, transition.draggableItem.definition.minRowSpan ?? 1);
+    if (lastPosition.y > (transition.operation === "resize" ? position + minSize : 0)) {
       updateManualItemTransition(transition, [
         ...transition.path,
         new Position({ x: lastPosition.x, y: lastPosition.y - 1 }),
@@ -309,8 +323,8 @@ export default function DashboardLayout<D>({ items, renderItem, onItemsChange, e
 
             // Take item's layout size or item's definition defaults to be used for insert and reorder.
             const itemSize = layoutItem ?? {
-              width: item.definition.defaultColumnSpan,
-              height: item.definition.defaultRowSpan,
+              width: Math.max(item.definition.defaultColumnSpan, item.definition.minColumnSpan ?? 1),
+              height: Math.max(item.definition.defaultRowSpan, item.definition.minRowSpan ?? 1, MIN_ROW_SPAN),
             };
 
             const itemMaxSize = isResizing && layoutItem ? { width: columns - layoutItem.x, height: 999 } : itemSize;

--- a/src/palette/internal.tsx
+++ b/src/palette/internal.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useRef } from "react";
+import { MIN_ROW_SPAN } from "../internal/constants";
 import { Direction, ItemId } from "../internal/interfaces";
 import { ItemContainer, ItemContainerRef } from "../internal/item-container";
 import { DashboardPaletteProps } from "./interfaces";
@@ -45,25 +46,31 @@ export default function DashboardPalette<D>({ items, renderItem }: DashboardPale
   return (
     <div ref={paletteRef} className={styles.root}>
       <SpaceBetween size="l">
-        {items.map((item, index) => (
-          <ItemContainer
-            ref={(elem) => {
-              if (elem) {
-                itemContainerRef.current[item.id] = elem;
-              } else {
-                delete itemContainerRef.current[item.id];
-              }
-            }}
-            key={item.id}
-            item={item}
-            itemSize={{ width: item.definition.defaultColumnSpan, height: item.definition.defaultRowSpan }}
-            itemMaxSize={{ width: item.definition.defaultColumnSpan, height: item.definition.defaultRowSpan }}
-            transform={null}
-            onNavigate={(direction) => onItemNavigate(index, direction)}
-          >
-            <div data-item-id={item.id}>{renderItem(item)}</div>
-          </ItemContainer>
-        ))}
+        {items.map((item, index) => {
+          const itemSize = {
+            width: Math.max(item.definition.defaultColumnSpan, item.definition.minColumnSpan ?? 1),
+            height: Math.max(item.definition.defaultRowSpan, item.definition.minRowSpan ?? 1, MIN_ROW_SPAN),
+          };
+          return (
+            <ItemContainer
+              ref={(elem) => {
+                if (elem) {
+                  itemContainerRef.current[item.id] = elem;
+                } else {
+                  delete itemContainerRef.current[item.id];
+                }
+              }}
+              key={item.id}
+              item={item}
+              itemSize={itemSize}
+              itemMaxSize={itemSize}
+              transform={null}
+              onNavigate={(direction) => onItemNavigate(index, direction)}
+            >
+              <div data-item-id={item.id}>{renderItem(item)}</div>
+            </ItemContainer>
+          );
+        })}
       </SpaceBetween>
     </div>
   );

--- a/test/dnd/keyboard-interactions.test.ts
+++ b/test/dnd/keyboard-interactions.test.ts
@@ -11,6 +11,11 @@ const dashboardItemHandle = (id: string) => dashboardWrapper.findItemById(id).fi
 const dashboardItemResizeHandle = (id: string) => dashboardWrapper.findItemById(id).findResizeHandle().toSelector();
 const paletteItemHandle = (id: string) => paletteWrapper.findItemById(id).findDragHandle().toSelector();
 
+function makeQueryUrl(layout: string[][], palette: string[]) {
+  const query = `layout=${JSON.stringify(layout)}&palette=${JSON.stringify(palette)}`;
+  return `/index.html#/dnd/engine-query-test?${query}`;
+}
+
 function setupTest(url: string, testFn: (page: DndPageObject, browser: WebdriverIO.Browser) => Promise<void>) {
   return useBrowser(async (browser) => {
     await browser.url(url);
@@ -72,6 +77,8 @@ describe("items reordered with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["B", "A", "C", "D"],
+        ["B", "A", "C", "D"],
+        ["E", "F", "G", "H"],
         ["E", "F", "G", "H"],
       ]);
     })
@@ -87,6 +94,8 @@ describe("items reordered with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "F", "G", "H"],
         ["E", "F", "G", "H"],
       ]);
     })
@@ -105,8 +114,11 @@ describe("items resized with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "A", "B", "C"],
+        ["A", "A", "B", "C"],
         ["A", "A", "G", "D"],
+        ["E", "F", "G", "D"],
         ["E", "F", " ", "H"],
+        [" ", " ", " ", "H"],
       ]);
     })
   );
@@ -122,9 +134,72 @@ describe("items resized with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "F", "G", "H"],
         ["E", "F", "G", "H"],
       ]);
     })
+  );
+
+  test(
+    "resizes 4x2 item down to 2x1 one step at a time",
+    setupTest(
+      makeQueryUrl(
+        [
+          ["A", "A", "B", "C"],
+          ["A", "A", "B", "C"],
+          ["A", "A", "D", "E"],
+          ["A", "A", "D", "E"],
+          ["F", "G", " ", " "],
+          ["F", "G", " ", " "],
+        ],
+        []
+      ),
+      async (page) => {
+        await page.focus(dashboardItemResizeHandle("A"));
+        await page.keys(["Enter"]);
+        await page.keys(["ArrowLeft"]);
+        expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+
+        await page.keys(["ArrowUp"]);
+        await page.keys(["ArrowUp"]);
+        expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+
+        await page.keys(["Enter"]);
+        expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+      }
+    )
+  );
+
+  test(
+    "can't resize below min row/col span",
+    setupTest(
+      makeQueryUrl(
+        [
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+        ],
+        []
+      ),
+      async (page) => {
+        await page.focus(dashboardItemResizeHandle("X"));
+        await page.keys(["Enter"]);
+        await page.keys(["ArrowLeft"]);
+        await page.keys(["ArrowUp"]);
+
+        expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+
+        await page.keys(["Enter"]);
+        await expect(page.getGrid()).resolves.toEqual([
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+          ["X", "X", " ", " "],
+        ]);
+      }
+    )
   );
 });
 
@@ -140,7 +215,10 @@ describe("items inserted with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "F", "G", "H"],
+        ["E", "F", "G", "H"],
+        [" ", " ", " ", "I"],
         [" ", " ", " ", "I"],
       ]);
     })
@@ -157,6 +235,8 @@ describe("items inserted with keyboard", () => {
 
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "F", "G", "H"],
         ["E", "F", "G", "H"],
       ]);
     })

--- a/test/dnd/layout.test.ts
+++ b/test/dnd/layout.test.ts
@@ -29,6 +29,8 @@ test(
     makeQueryUrl(
       [
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "B", "G", "H"],
         ["E", "B", "G", "H"],
       ],
       []
@@ -37,7 +39,10 @@ test(
       await page.mouseDown(dashboardWrapper.findItemById("A").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "B", "G", "H"],
+        ["E", "B", "G", "H"],
+        [" ", " ", " ", " "],
         [" ", " ", " ", " "],
       ]);
       await page.mouseUp();
@@ -45,7 +50,11 @@ test(
       await page.mouseDown(dashboardWrapper.findItemById("B").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "B", "G", "H"],
+        ["E", "B", "G", "H"],
+        [" ", " ", " ", " "],
+        [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
       ]);
@@ -59,6 +68,8 @@ test(
     makeQueryUrl(
       [
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "F", "G", "H"],
         ["E", "F", "G", "H"],
       ],
       ["I", "X"]
@@ -67,7 +78,10 @@ test(
       await page.mouseDown(paletteWrapper.findItemById("I").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "F", "G", "H"],
+        ["E", "F", "G", "H"],
+        [" ", " ", " ", " "],
         [" ", " ", " ", " "],
       ]);
       await page.mouseUp();
@@ -75,7 +89,11 @@ test(
       await page.mouseDown(paletteWrapper.findItemById("X").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "F", "G", "H"],
+        ["E", "F", "G", "H"],
+        [" ", " ", " ", " "],
+        [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
       ]);
@@ -89,6 +107,8 @@ test(
     makeQueryUrl(
       [
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        [" ", "F", "G", "H"],
         [" ", "F", "G", "H"],
       ],
       []
@@ -97,19 +117,25 @@ test(
       await page.mouseDown(dashboardWrapper.findItemById("A").findResizeHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        [" ", "F", "G", "H"],
         [" ", "F", "G", "H"],
       ]);
 
       await page.mouseMove(0, 250);
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        [" ", "F", "G", "H"],
         [" ", "F", "G", "H"],
         [" ", " ", " ", " "],
       ]);
 
-      await page.mouseMove(0, 250);
+      await page.mouseMove(0, 100);
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        [" ", "F", "G", "H"],
         [" ", "F", "G", "H"],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],


### PR DESCRIPTION
### Description

Fixed a bug when resizeable item (with keyboard) would have incorrect size if resizing down to 1x1, see:

https://user-images.githubusercontent.com/20790937/207059014-db1a39c7-ecdf-4248-b206-d48fe7863816.mov

### How has this been tested?

Added e2e test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
