### PR TITLE
fix: Only activate drag on left click

### DIFF
--- a/src/internal/handle/index.tsx
+++ b/src/internal/handle/index.tsx
@@ -1,11 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
-import { ButtonHTMLAttributes, ForwardedRef, forwardRef } from "react";
+import { ButtonHTMLAttributes, ForwardedRef, PointerEvent, forwardRef } from "react";
 import styles from "./styles.css.js";
 
 function Handle(props: ButtonHTMLAttributes<HTMLButtonElement>, ref: ForwardedRef<HTMLButtonElement>) {
-  return <button {...props} className={clsx(styles.handle, props.className)} ref={ref} />;
+  function handlePointerDown(event: PointerEvent<HTMLButtonElement>) {
+    if (event.button !== 0) {
+      return;
+    }
+    props.onPointerDown?.(event);
+  }
+
+  return (
+    <button {...props} onPointerDown={handlePointerDown} className={clsx(styles.handle, props.className)} ref={ref} />
+  );
 }
 
 export default forwardRef(Handle);


### PR DESCRIPTION
### Description

Right and middle mouse clicks should not activate drag operations

Related links, issue #, if available: n/a

### How has this been tested?

Locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
