### PR TITLE
Items with colspan > 1 can be inserted into 1-column layout

### DIFF
--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -17,6 +17,7 @@ export default function Grid({ layout, children, columns, rows }: GridProps) {
   const zipped = zipTwoArrays(layout, Children.toArray(children));
 
   const getWidth = (colspan: number) => {
+    colspan = Math.min(columns, colspan);
     const cellWidth = ((gridWidth || 0) - (columns - 1) * GRID_GAP) / columns;
     return colspan * cellWidth + (colspan - 1) * GRID_GAP;
   };

--- a/src/internal/utils/layout.ts
+++ b/src/internal/utils/layout.ts
@@ -10,7 +10,10 @@ export function createItemsLayout(items: readonly DashboardItem<unknown>[], colu
 
   for (const { id, columnSpan, rowSpan, columnOffset, definition } of items) {
     const startCol = Math.min(columns - 1, columnOffset);
-    const allowedColSpan = Math.max(definition.minColumnSpan ?? 1, Math.min(columns - startCol, columnSpan));
+    const allowedColSpan = Math.min(
+      columns,
+      Math.max(definition.minColumnSpan ?? 1, Math.min(columns - startCol, columnSpan))
+    );
     const allowedRowSpan = Math.max(MIN_ROW_SPAN, definition.minRowSpan ?? 1, rowSpan);
 
     let itemRow = 0;

--- a/test/dnd/layout.test.ts
+++ b/test/dnd/layout.test.ts
@@ -169,3 +169,19 @@ test(
     expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })
 );
+
+test(
+  "palette item with min colspan=2 can be inserted into 1-column layout",
+  setupTest("/index.html#/dnd/engine-a2p-test", async (page) => {
+    await page.setWindowSize({ width: 800, height: 800 });
+
+    await page.focus(paletteWrapper.findItemById("R").findDragHandle().toSelector());
+    await page.keys(["Enter"]);
+
+    await page.keys(["ArrowLeft"]);
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+
+    await page.keys(["Enter"]);
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+  })
+);


### PR DESCRIPTION
### Description

Fixed size calculations to support insertion of item with colspan > 1 into 1-column layout.

### How has this been tested?

Added new e2e test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
