### PR TITLE
Fixed min width getter

### DIFF
--- a/src/internal/utils/layout.ts
+++ b/src/internal/utils/layout.ts
@@ -74,7 +74,7 @@ export function exportItemsLayout<D>(
 
 export function getMinItemSize(item: DashboardItemBase<unknown>) {
   return {
-    width: Math.min(1, item.definition.minColumnSpan ?? 1),
+    width: Math.max(1, item.definition.minColumnSpan ?? 1),
     height: Math.max(MIN_ROW_SPAN, item.definition.minRowSpan ?? 1),
   };
 }


### PR DESCRIPTION
### Description

With incorrect min width check it was possible to resize an item below the min width temporarily. 

### How has this been tested?

An existing e2e test catches the change.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
