### PR TITLE
feat: palette item preview

### DIFF
--- a/src/internal/dnd-controller/controller.ts
+++ b/src/internal/dnd-controller/controller.ts
@@ -30,7 +30,7 @@ interface DragDetail {
   draggableElement: HTMLElement;
 }
 
-interface DragAndDropEvents {
+export interface DragAndDropEvents {
   start: (data: DragAndDropData) => void;
   update: (data: DragAndDropData) => void;
   submit: () => void;

--- a/src/palette/__tests__/palette.test.tsx
+++ b/src/palette/__tests__/palette.test.tsx
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { act, cleanup, render as libRender } from "@testing-library/react";
+import { ReactElement, forwardRef } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+import { DragAndDropEvents, useDragSubscription } from "../../../lib/components/internal/dnd-controller/controller";
+import { EventEmitter } from "../../../lib/components/internal/dnd-controller/event-emitter";
+import itemStyles from "../../../lib/components/item/styles.css.js";
+import DashboardPalette, { DashboardPaletteProps } from "../../../lib/components/palette";
+import createWrapper, { PaletteWrapper } from "../../../lib/components/test-utils/dom";
+
+afterEach(cleanup);
+
+vi.mock("../../../lib/components/internal/dnd-controller/controller", () => ({ useDragSubscription: vi.fn() }));
+vi.mock("../../../lib/components/internal/item-container", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ItemContainer: forwardRef(({ children }: { children: ReactElement }, ref) => <div>{children}</div>),
+}));
+
+class FakeEmitter extends EventEmitter<DragAndDropEvents> {
+  constructor() {
+    vi.mocked(useDragSubscription).mockImplementation((event, handler) => {
+      this.on(event, handler);
+    });
+    super();
+  }
+
+  public emit(event: keyof DragAndDropEvents, ...data: Parameters<DragAndDropEvents[keyof DragAndDropEvents]>) {
+    super.emit(event, ...data);
+  }
+}
+
+function render(jsx: ReactElement) {
+  libRender(jsx);
+  return createWrapper().findPalette()!;
+}
+
+const defaultProps: DashboardPaletteProps = {
+  i18nStrings: {},
+  items: [
+    { id: "first", definition: { defaultColumnSpan: 1, defaultRowSpan: 1 }, data: {} },
+    { id: "second", definition: { defaultColumnSpan: 1, defaultRowSpan: 1 }, data: {} },
+  ],
+  renderItem: (item, { showPreview }) => (
+    <div className={itemStyles.root}>
+      <h2>{item.id}</h2>
+      <span data-testid="showPreview">{`${showPreview}`}</span>
+    </div>
+  ),
+};
+
+function getPreviewState(wrapper: PaletteWrapper) {
+  return wrapper.findItems().map((item) => item.find('[data-testid="showPreview"]')!.getElement().textContent);
+}
+
+test("renders palette and items", () => {
+  const wrapper = render(<DashboardPalette {...defaultProps} />);
+  expect(wrapper.findItems()).toHaveLength(2);
+});
+
+test("updates preview state when drop target changes", () => {
+  const fakeEmitter = new FakeEmitter();
+  const wrapper = render(<DashboardPalette {...defaultProps} />);
+  expect(getPreviewState(wrapper)).toEqual(["false", "false"]);
+  act(() => fakeEmitter.emit("update", { draggableItem: { id: "second" }, dropTarget: {} } as any));
+  expect(getPreviewState(wrapper)).toEqual(["false", "true"]);
+  act(() => fakeEmitter.emit("update", { draggableItem: { id: "second" }, dropTarget: null } as any));
+  expect(getPreviewState(wrapper)).toEqual(["false", "false"]);
+});
+
+test("updates preview state when operation submits", () => {
+  const fakeEmitter = new FakeEmitter();
+  const wrapper = render(<DashboardPalette {...defaultProps} />);
+  act(() => fakeEmitter.emit("update", { draggableItem: { id: "second" }, dropTarget: {} } as any));
+  expect(getPreviewState(wrapper)).toEqual(["false", "true"]);
+  act(() => fakeEmitter.emit("submit"));
+  expect(getPreviewState(wrapper)).toEqual(["false", "false"]);
+});
+
+test("updates preview state when operation discards", () => {
+  const fakeEmitter = new FakeEmitter();
+  const wrapper = render(<DashboardPalette {...defaultProps} />);
+  act(() => fakeEmitter.emit("update", { draggableItem: { id: "second" }, dropTarget: {} } as any));
+  expect(getPreviewState(wrapper)).toEqual(["false", "true"]);
+  act(() => fakeEmitter.emit("discard"));
+  expect(getPreviewState(wrapper)).toEqual(["false", "false"]);
+});

--- a/src/palette/interfaces.ts
+++ b/src/palette/interfaces.ts
@@ -12,7 +12,7 @@ export interface DashboardPaletteProps<D = DataFallbackType> {
   /**
    * Specifies a function to render a palette item content. The return value must include dashboard item component.
    */
-  renderItem(item: PaletteProps.Item<D>): JSX.Element;
+  renderItem(item: PaletteProps.Item<D>, context: PaletteProps.ItemContext): JSX.Element;
 
   /**
    * An object containing all the necessary localized strings required by the component.
@@ -22,6 +22,10 @@ export interface DashboardPaletteProps<D = DataFallbackType> {
 
 export namespace PaletteProps {
   export type Item<D = DataFallbackType> = DashboardItemBase<D>;
+
+  export interface ItemContext {
+    showPreview: boolean;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface I18nStrings {}

--- a/src/test-utils/dom/palette/index.ts
+++ b/src/test-utils/dom/palette/index.ts
@@ -7,6 +7,12 @@ import PaletteItemWrapper from "../palette-item";
 export default class PaletteWrapper extends ComponentWrapper {
   static rootSelector: string = paletteStyles.root;
 
+  findItems() {
+    return this.findAllByClassName(PaletteItemWrapper.rootSelector).map(
+      (wrapper) => new PaletteItemWrapper(wrapper.getElement())
+    );
+  }
+
   findItemById(itemId: string): null | PaletteItemWrapper {
     return this.findComponent(`[data-item-id=${itemId}]`, PaletteItemWrapper);
   }


### PR DESCRIPTION
### Description

Allow palette items to show preview state when dragged over a dashboard

Related links, issue #, if available: n/a

### How has this been tested?

Added a couple unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
