### PR TITLE
Fix insertion test

### DIFF
--- a/test/dnd/keyboard-interactions.test.ts
+++ b/test/dnd/keyboard-interactions.test.ts
@@ -225,8 +225,10 @@ describe("items inserted with keyboard", () => {
       expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
 
       await page.keys(["ArrowDown"]);
+      await page.keys(["ArrowDown"]);
       expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
 
+      await page.keys(["ArrowDown"]);
       await page.keys(["ArrowDown"]);
       expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
 


### PR DESCRIPTION
### Description

With the new approach introduced in https://github.com/cloudscape-design/dashboard-components/pull/124, the keyboard item insertion now delegated to the layout and now the item requires more steps to reach the landing position.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
