### PR TITLE
Fix item resize with pointer offsets and placement

### DIFF
--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -112,7 +112,10 @@ function ItemContainerComponent(
         setTransition({
           operation,
           itemId: draggableItem.id,
-          sizeTransform: { width: Math.max(minWidth, Math.min(maxWidth, width)), height: Math.max(minHeight, height) },
+          sizeTransform: {
+            width: Math.max(minWidth, Math.min(maxWidth, width - pointerOffset.x)),
+            height: Math.max(minHeight, height - pointerOffset.y),
+          },
           positionTransform: null,
         });
       } else {
@@ -280,11 +283,11 @@ function ItemContainerComponent(
   function getPointerDragStyles(transition: Transition): CSSProperties {
     return {
       zIndex: 5000,
-      position: transition ? "fixed" : undefined,
+      position: transition.operation === "resize" ? "absolute" : "fixed",
       left: transition.positionTransform?.x,
       top: transition.positionTransform?.y,
-      width: transition?.sizeTransform?.width,
-      height: transition?.sizeTransform?.height,
+      width: transition.sizeTransform?.width,
+      height: transition.sizeTransform?.height,
     };
   }
 


### PR DESCRIPTION
### Description

Resized items do not override position transform and can't use fixed placement.

Also, the pointer offset must be applied to the size transform for those.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
