### PR TITLE
Fixed gap to be 16px (in both compact and comfortable modes)

### DIFF
--- a/src/internal/grid/styles.scss
+++ b/src/internal/grid/styles.scss
@@ -1,11 +1,9 @@
-@use "../../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
-
 .grid {
   display: grid;
   justify-items: stretch;
   justify-content: stretch;
   align-content: stretch;
-  gap: cs.$space-scaled-m;
+  gap: 16px; // Can't use design tokens for the gap because it is used in calculations;
   grid-auto-rows: 100px;
 }
 


### PR DESCRIPTION
### Description

Alternatively, we can have an observer in code to adjust the gap in js when the mode changes. But I think the current approach is a good first step.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
