### PR TITLE
Make transforms belong to grid

### DIFF
--- a/src/internal/grid-context.ts
+++ b/src/internal/grid-context.ts
@@ -5,8 +5,6 @@ import { createContext, useContext } from "react";
 export interface GridContext {
   getWidth: (colspan: number) => number;
   getHeight: (rowspan: number) => number;
-  getColOffset: (x: number) => number;
-  getRowOffset: (y: number) => number;
 }
 
 const Context = createContext<GridContext | null>(null);

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
+import { CSS as CSSUtil } from "@dnd-kit/utilities";
 import { Children } from "react";
 import { GridContextProvider } from "../grid-context";
 
@@ -12,7 +14,7 @@ import { zipTwoArrays } from "./utils";
 const GRID_GAP = 16;
 const ROWSPAN_HEIGHT = 100;
 
-export default function Grid({ layout, children, columns, rows }: GridProps) {
+export default function Grid({ layout, children, columns, rows, transforms }: GridProps) {
   const [gridWidth, containerQueryRef] = useContainerQuery((entry) => entry.contentBoxWidth, []);
   const zipped = zipTwoArrays(layout, Children.toArray(children));
 
@@ -26,13 +28,30 @@ export default function Grid({ layout, children, columns, rows }: GridProps) {
   const getRowOffset = (y: number) => getHeight(y) + GRID_GAP;
 
   return (
-    <GridContextProvider value={{ getWidth, getHeight, getColOffset, getRowOffset }}>
+    <GridContextProvider value={{ getWidth, getHeight }}>
       <div ref={containerQueryRef} data-columns={columns} data-rows={rows} className={styles.grid}>
-        {zipped.map(([item, children]) => (
-          <GridItem key={item.id} item={item}>
-            {children}
-          </GridItem>
-        ))}
+        {zipped.map(([item, children]) => {
+          const contentTransform = transforms?.[item.id];
+          const contentClassName = contentTransform ? styles.transformed : undefined;
+          const contentStyle = contentTransform
+            ? {
+                transform: CSSUtil.Transform.toString({
+                  x: getColOffset(contentTransform.x),
+                  y: getRowOffset(contentTransform.y),
+                  scaleX: 1,
+                  scaleY: 1,
+                }),
+                width: getWidth(contentTransform.width) + "px",
+                height: getHeight(contentTransform.height) + "px",
+              }
+            : undefined;
+
+          return (
+            <GridItem key={item.id} item={item} contentClassName={contentClassName} contentStyle={contentStyle}>
+              {children}
+            </GridItem>
+          );
+        })}
       </div>
     </GridContextProvider>
   );

--- a/src/internal/grid/interfaces.ts
+++ b/src/internal/grid/interfaces.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode } from "react";
-import { GridLayoutItem } from "../interfaces";
+import { GridLayoutItem, ItemId, Transform } from "../interfaces";
 
 export interface GridProps {
   layout: GridLayoutItem[];
   columns: number;
   rows: number;
+  transforms?: { [id: ItemId]: Transform };
   children?: ReactNode;
 }

--- a/src/internal/grid/item.tsx
+++ b/src/internal/grid/item.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import clsx from "clsx";
 import { ReactNode, memo } from "react";
 import { GridLayoutItem } from "../interfaces";
 import styles from "./styles.css.js";
@@ -8,9 +9,11 @@ import styles from "./styles.css.js";
 export interface GridItemProps {
   item: GridLayoutItem;
   children?: ReactNode;
+  contentClassName?: string;
+  contentStyle?: React.CSSProperties;
 }
 
-const GridItem = ({ children, item }: GridItemProps) => {
+const GridItem = ({ children, item, contentClassName, contentStyle }: GridItemProps) => {
   // Grid row start can not be set as part of a CSS class names, since we have a potentially infinite height grid.
   return (
     <div
@@ -21,7 +24,9 @@ const GridItem = ({ children, item }: GridItemProps) => {
       className={styles.grid__item}
       style={{ gridRowStart: item.y + 1, gridRowEnd: `span ${item.height}` }}
     >
-      {children}
+      <div className={clsx(styles.grid__item__content, contentClassName)} style={contentStyle}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/internal/grid/styles.scss
+++ b/src/internal/grid/styles.scss
@@ -33,3 +33,15 @@ $columns: 4;
     grid-column-start: $i;
   }
 }
+
+.grid__item__content {
+  width: 100%;
+  height: 100%;
+
+  &.transformed {
+    z-index: 1;
+    position: absolute;
+    transition: transform 200ms;
+    transition-timing-function: ease;
+  }
+}

--- a/src/item/__tests__/dashboard-item.test.tsx
+++ b/src/item/__tests__/dashboard-item.test.tsx
@@ -12,14 +12,11 @@ function render(jsx: ReactElement) {
   return libRender(jsx, {
     wrapper: function ItemContextWrapper({ children }) {
       return (
-        <GridContextProvider
-          value={{ getWidth: () => 1, getHeight: () => 1, getColOffset: () => 1, getRowOffset: () => 1 }}
-        >
+        <GridContextProvider value={{ getWidth: () => 1, getHeight: () => 1 }}>
           <ItemContainer
             item={{ id: "1", definition: { defaultColumnSpan: 1, defaultRowSpan: 1 }, data: null }}
             itemSize={{ width: 1, height: 1 }}
             itemMaxSize={{ width: 1, height: 1 }}
-            transform={null}
             onNavigate={() => undefined}
             dragHandleAriaLabel="Drag handle aria label"
             dragHandleAriaDescription="Drag handle aria description"

--- a/src/palette/internal.tsx
+++ b/src/palette/internal.tsx
@@ -100,7 +100,6 @@ export default function DashboardPalette<D>({ items, renderItem, i18nStrings }: 
             item={item}
             itemSize={getDefaultItemSize(item)}
             itemMaxSize={getDefaultItemSize(item)}
-            transform={null}
             onNavigate={(direction) => onItemNavigate(index, direction)}
             onBorrow={onBorrow}
             dragHandleAriaLabel={i18nStrings.itemDragHandleAriaLabel(item, index, items)}


### PR DESCRIPTION
### Description

This refactoring allows to remove getColOffset/getRowOffset from grid context and simplify item container.

It also makes the overall code better reasonable as now items are unaware of grid-specific transforms.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
