### PR TITLE
Allow bottom position of split-panel

### DIFF
--- a/pages/with-app-layout/dashboard-with-app-layout.page.tsx
+++ b/pages/with-app-layout/dashboard-with-app-layout.page.tsx
@@ -12,6 +12,7 @@ export default function () {
   const [layoutWidgets, setLayoutWidgets] = useState(demoLayoutItems);
   const [paletteWidgets, setPaletteWidgets] = useState(demoPaletteItems);
   const [splitPanelOpen, setSplitPanelOpen] = useState(false);
+  const [splitPanelPosition, setSpitPanelPosition] = useState<"side" | "bottom">("side");
 
   return (
     <ScreenshotArea>
@@ -74,7 +75,6 @@ export default function () {
           splitPanelOpen && (
             <SplitPanel
               header="Add widgets"
-              hidePreferencesButton={true}
               i18nStrings={{
                 preferencesTitle: "Split panel preferences",
                 preferencesPositionLabel: "Split panel position",
@@ -106,9 +106,10 @@ export default function () {
         }
         navigationHide={true}
         toolsHide={true}
-        splitPanelPreferences={{ position: "side" }}
+        splitPanelPreferences={{ position: splitPanelPosition }}
         splitPanelOpen={splitPanelOpen}
         onSplitPanelToggle={({ detail }) => setSplitPanelOpen(detail.open)}
+        onSplitPanelPreferencesChange={({ detail }) => setSpitPanelPosition(detail.position)}
         ariaLabels={{
           navigation: "Side navigation",
           navigationToggle: "Open side navigation",


### PR DESCRIPTION
### Description

The bottom placement of the split-panel is not something we recommend (although it does it anyways when in mobile) but the change allows to test if the insertion works well when the palette has a different placement.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
