### PR TITLE
Fixed resize below baseline issue

### DIFF
--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -245,7 +245,10 @@ function updateTransitionWithPointerEvent<D>(
   const itemHeight = layoutItem ? layoutItem.height : getItemHeight(transition);
   const itemSize = itemWidth * itemHeight;
 
-  if (transition.operation !== "resize" && collisionIds.length < itemSize) {
+  const isOutOfBoundaries =
+    transition.operation !== "resize" ? collisionIds.length < itemSize : collisionIds.length === 0;
+
+  if (isOutOfBoundaries) {
     return {
       transition: { ...transition, collisionIds: new Set(), layoutShift: null, insertionDirection: null },
       announcement: null,

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -116,9 +116,9 @@ function ItemContainerComponent(
       const [width, height] = [collisionRect.right - collisionRect.left, collisionRect.bottom - collisionRect.top];
       const pointerOffset = pointerOffsetRef.current;
 
-      if (operation === "resize") {
-        const { width: minWidth, height: minHeight } = dropTarget!.scale(getMinItemSize(draggableItem));
-        const { width: maxWidth } = dropTarget!.scale(itemMaxSize);
+      if (operation === "resize" && dropTarget) {
+        const { width: minWidth, height: minHeight } = dropTarget.scale(getMinItemSize(draggableItem));
+        const { width: maxWidth } = dropTarget.scale(itemMaxSize);
         setTransition({
           operation,
           interactionType,
@@ -129,7 +129,7 @@ function ItemContainerComponent(
           },
           positionTransform: null,
         });
-      } else {
+      } else if (operation === "insert" || operation === "reorder") {
         setTransition({
           operation,
           interactionType,

--- a/test/functional/board-layout/mouse-interactions.test.ts
+++ b/test/functional/board-layout/mouse-interactions.test.ts
@@ -124,3 +124,33 @@ test(
     }
   )
 );
+
+test(
+  "no errors in the console when trying to resize below item's baseline",
+  setupTest(
+    makeQueryUrl(
+      [
+        ["A", "A", " ", " "],
+        ["A", "A", " ", " "],
+        ["B", "B", " ", " "],
+        ["B", "B", " ", " "],
+      ],
+      []
+    ),
+    async (page) => {
+      await page.mouseDown(boardWrapper.findItemById("B").findResizeHandle().toSelector());
+      await page.mouseMove(0, -300);
+      await page.mouseUp();
+      await expect(page.getGrid().then((grid) => grid.map((r) => r.join(" ")).join("\n"))).resolves.toEqual(
+        [
+          ["A", "A", " ", " "],
+          ["A", "A", " ", " "],
+          ["B", "B", " ", " "],
+          ["B", "B", " ", " "],
+        ]
+          .map((r) => r.join(" "))
+          .join("\n")
+      );
+    }
+  )
+);


### PR DESCRIPTION
### Description

Fixes a bug where when trying to resize an item below its top coordinate there was an exception thrown from both board and item-container listeners because no collisions/dropTarget are available in that case.

### How has this been tested?

Added new integ test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
