### PR TITLE
Fix board extra rows calculation

### DIFF
--- a/src/board/__tests__/transition.test.ts
+++ b/src/board/__tests__/transition.test.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from "vitest";
+import { fromMatrix } from "../../internal/debug-tools";
+import { Operation } from "../../internal/dnd-controller/controller";
+import { GridLayout } from "../../internal/interfaces";
+import { LayoutShift } from "../../internal/layout-engine/interfaces";
+import { Transition, selectTransitionRows } from "../transition";
+
+function createMockTransition(
+  operation: Operation,
+  itemsLayout: GridLayout,
+  layoutShift: LayoutShift
+): Transition<null> {
+  return {
+    operation,
+    interactionType: "keyboard",
+    itemsLayout,
+    insertionDirection: null,
+    draggableItem: { id: "X", definition: { defaultColumnSpan: 1, defaultRowSpan: 2 }, data: null },
+    draggableElement: null as unknown as HTMLElement,
+    acquiredItem: null,
+    collisionIds: new Set(),
+    layoutShift,
+    layoutShiftWithRefloat: null,
+    path: [],
+  };
+}
+
+describe("selectTransitionRows", () => {
+  test("returns 0 if no transition", () => {
+    const transition = null;
+    const rows = selectTransitionRows({ transition, announcement: null });
+    expect(rows).toBe(0);
+  });
+
+  test("returns original amount of rows for resize when not reached bottom", () => {
+    const transition = createMockTransition(
+      "resize",
+      fromMatrix([
+        ["X", "X", "A", "A"],
+        [" ", " ", "A", "A"],
+      ]),
+      {
+        current: fromMatrix([
+          ["X", "X", "A", "A"],
+          [" ", " ", "A", "A"],
+        ]),
+        next: fromMatrix([
+          ["X", "X", "A", "A"],
+          [" ", " ", "A", "A"],
+        ]),
+        moves: [],
+        conflicts: [],
+      }
+    );
+    const rows = selectTransitionRows({ transition, announcement: null });
+    expect(rows).toBe(2);
+  });
+
+  test("returns original amount of rows plus one for resize when reached bottom", () => {
+    const transition = createMockTransition(
+      "resize",
+      fromMatrix([
+        ["X", "X", "A", "A"],
+        [" ", " ", "A", "A"],
+      ]),
+      {
+        current: fromMatrix([
+          ["X", "X", "A", "A"],
+          [" ", " ", "A", "A"],
+        ]),
+        next: fromMatrix([
+          ["X", "X", "A", "A"],
+          ["X", "X", "A", "A"],
+        ]),
+        moves: [],
+        conflicts: [],
+      }
+    );
+    const rows = selectTransitionRows({ transition, announcement: null });
+    expect(rows).toBe(3);
+  });
+
+  test("returns original amount of rows plus item height for reorder and insert", () => {
+    const itemsLayout = fromMatrix([
+      ["X", "X", "A", "A"],
+      ["X", "X", "A", "A"],
+      [" ", " ", "A", "A"],
+    ]);
+    const layoutShift = { current: itemsLayout, next: itemsLayout, moves: [], conflicts: [] };
+
+    const reorderTransition = createMockTransition("reorder", itemsLayout, layoutShift);
+    expect(selectTransitionRows({ transition: reorderTransition, announcement: null })).toBe(5);
+
+    const insertTransition = createMockTransition("reorder", itemsLayout, layoutShift);
+    expect(selectTransitionRows({ transition: insertTransition, announcement: null })).toBe(5);
+  });
+
+  test("returns next layout amount of rows if it is bigger", () => {
+    const current = fromMatrix([
+      ["X", "A"],
+      [" ", "A"],
+    ]);
+    const next = fromMatrix([
+      ["X", "A"],
+      [" ", "A"],
+      [" ", "A"],
+      [" ", "A"],
+    ]);
+
+    const resizeTransition = createMockTransition("resize", current, { current, next, moves: [], conflicts: [] });
+    expect(selectTransitionRows({ transition: resizeTransition, announcement: null })).toBe(4);
+
+    const reorderTransition = createMockTransition("reorder", current, { current, next, moves: [], conflicts: [] });
+    expect(selectTransitionRows({ transition: reorderTransition, announcement: null })).toBe(4);
+
+    const insertTransition = createMockTransition("insert", current, { current, next, moves: [], conflicts: [] });
+    expect(selectTransitionRows({ transition: insertTransition, announcement: null })).toBe(4);
+  });
+});

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -407,6 +407,7 @@ function getLayoutColumns<D>(transition: Transition<D>) {
 // The rows can be overridden during transition to create more drop targets at the bottom.
 function getLayoutRows<D>(transition: Transition<D>) {
   const layout = transition.layoutShift?.next ?? transition.itemsLayout;
+
   const layoutItem = layout.items.find((it) => it.id === transition.draggableItem.id);
   const itemHeight = layoutItem?.height ?? getItemHeight(transition);
   // Add extra row for resize when already at the bottom.
@@ -415,7 +416,7 @@ function getLayoutRows<D>(transition: Transition<D>) {
   }
   // Add extra row(s) for reorder/insert based on item's height.
   else {
-    return transition.itemsLayout.rows + itemHeight;
+    return Math.max(layout.rows, transition.itemsLayout.rows + itemHeight);
   }
 }
 

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import useBrowser from "@cloudscape-design/browser-test-tools/use-browser";
 import { expect, test } from "vitest";
+import gridStyles from "../../../lib/components/internal/grid/styles.selectors.js";
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { DndPageObject } from "./dnd-page-object.js";
 
@@ -140,6 +141,39 @@ test(
         ["A", " ", " ", " "],
         [" ", " ", " ", " "],
       ]);
+    }
+  )
+);
+
+test(
+  "creates extra rows when disturbed item moves partially outside the grid",
+  setupTest(
+    makeQueryUrl(
+      [
+        ["A", "A", "A", "B"],
+        ["A", "A", "A", "B"],
+        ["C", "C", "C", "B"],
+        ["C", "C", "C", "B"],
+        ["C", "C", "C", "B"],
+        ["C", "C", "C", "B"],
+        ["D", "D", "E", "E"],
+        ["D", "D", "E", "E"],
+        ["D", "D", "E", "E"],
+        ["D", "D", "E", "E"],
+      ],
+      []
+    ),
+    async (page) => {
+      const placeholderSelector = `.${gridStyles.default.grid__item}[data-row-span="1"]`;
+
+      await page.setWindowSize({ width: 1200, height: 1800 });
+      await expect(page.getElementsCount(placeholderSelector)).resolves.toBe(10 * 4);
+
+      await page.mouseDown(boardWrapper.findItemById("A").findDragHandle().toSelector());
+      await expect(page.getElementsCount(placeholderSelector)).resolves.toBe(12 * 4);
+
+      await page.mouseMove(0, 900);
+      await expect(page.getElementsCount(placeholderSelector)).resolves.toBe(14 * 4);
     }
   )
 );


### PR DESCRIPTION
### Description

When reordering it is possible for disturbed items to be pushed down below the rows + item.height. In that case we need to render more rows as otherwise the swap with the pushed down items might not be possible.

### How has this been tested?

Added new integ and unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
