### PR TITLE
chore: Publish documentation content inside npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     ".": "./index.js",
     "./board": "./board/index.js",
     "./board-item": "./board-item/index.js",
-    "./items-palette": "./items-palette/index.js"
+    "./items-palette": "./items-palette/index.js",
+    "./internal/api-docs/*.js": "./internal/api-docs/*.js"
   },
   "dependencies": {
     "@cloudscape-design/component-toolkit": "^1.0.0-beta",

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -6,7 +6,7 @@ import { documentComponents, documentTestUtils } from "@cloudscape-design/docume
 import { dashCase, listPublicDirs, writeSourceFile } from "./utils.js";
 
 const publicDirs = listPublicDirs("src");
-const targetDir = "lib/components-api";
+const targetDir = "lib/components/internal/api-docs";
 
 componentDocs();
 testUtilDocs();

--- a/scripts/package-json.js
+++ b/scripts/package-json.js
@@ -6,20 +6,12 @@ import { writeSourceFile } from "./utils.js";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
 
 mainPackage();
-docsPackage();
 
 function mainPackage() {
   writeJSON("lib/components/package.json", {
     ...pkg,
     // prevent postinstall scripts we use in our build from being published
     scripts: undefined,
-  });
-}
-
-function docsPackage() {
-  writeJSON("lib/components-api/package.json", {
-    name: "@cloudscape-design/dashboard-components-api",
-    version: pkg.version,
   });
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -23,6 +23,7 @@ export function listPublicDirs(baseDir) {
       (elem) =>
         !elem.startsWith("__") &&
         !elem.startsWith(".") &&
+        elem !== "api-docs" &&
         elem !== "internal" &&
         elem !== "index.tsx" &&
         elem !== "index.ts" &&

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const componentsDir = path.resolve(__dirname, "../../lib/components");
-const definitionsDir = path.resolve(__dirname, "../../lib/components-api/components");
+const definitionsDir = path.resolve(__dirname, "../../lib/components/internal/api-docs/components");
 
 export function getAllComponents(): string[] {
   return fs


### PR DESCRIPTION
### Description

Added API docs to the package. Sadly, our release infrastructure did not allow us to publish it as a separate module

Related links, issue #, if available: n/a

### How has this been tested?

Deployed to my dev-pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
