### PR TITLE
Palette item restores original size when moved away from the board

### DIFF
--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -91,6 +91,7 @@ function ItemContainerComponent(
   { item, acquired, itemSize, itemMaxSize, onKeyMove, children }: ItemContainerProps,
   ref: Ref<ItemContainerRef>
 ) {
+  const originalSizeRef = useRef({ width: 0, height: 0 });
   const pointerOffsetRef = useRef(new Coordinates({ x: 0, y: 0 }));
   const [transition, setTransition] = useState<null | Transition>(null);
   const itemRef = useRef<HTMLDivElement>(null);
@@ -138,7 +139,7 @@ function ItemContainerComponent(
           operation,
           interactionType,
           itemId: draggableItem.id,
-          sizeTransform: dropTarget ? dropTarget.scale(itemSize) : { width, height },
+          sizeTransform: dropTarget ? dropTarget.scale(itemSize) : originalSizeRef.current,
           positionTransform: { x: coordinates.x - pointerOffset.x, y: coordinates.y - pointerOffset.y },
           isBorrowed: !!transition?.isBorrowed,
         }));
@@ -259,6 +260,7 @@ function ItemContainerComponent(
     // Calculate the offset between item's top-left corner and the pointer landing position.
     const rect = itemRef.current!.getBoundingClientRect();
     pointerOffsetRef.current = new Coordinates({ x: event.clientX - rect.left, y: event.clientY - rect.top });
+    originalSizeRef.current = { width: rect.width, height: rect.height };
 
     draggableApi.start(!gridContext ? "insert" : "reorder", "pointer", Coordinates.fromEvent(event));
   }
@@ -271,6 +273,7 @@ function ItemContainerComponent(
     // Calculate the offset between item's bottom-right corner and the pointer landing position.
     const rect = itemRef.current!.getBoundingClientRect();
     pointerOffsetRef.current = new Coordinates({ x: event.clientX - rect.right, y: event.clientY - rect.bottom });
+    originalSizeRef.current = { width: rect.width, height: rect.height };
 
     draggableApi.start("resize", "pointer", Coordinates.fromEvent(event));
   }


### PR DESCRIPTION
### Description

Found during bug bash

### How has this been tested?

An existing screenshot tests captures the diff

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
