### PR TITLE
Fix test failing after merge

### DIFF
--- a/src/internal/utils/__tests__/rects.test.ts
+++ b/src/internal/utils/__tests__/rects.test.ts
@@ -54,19 +54,19 @@ describe("isIntersecting", () => {
     expect(isIntersecting(rect2, rect1)).toBe(true);
   });
 
-  test("returns true if one rect touches another", () => {
+  test("returns true if one rect intersects with another", () => {
     const source = { left: 2, right: 4, top: 2, bottom: 4 };
 
     // Touching source's top-left corner.
-    expect(isIntersecting(source, { left: 0, right: 2, top: 0, bottom: 2 })).toBe(true);
+    expect(isIntersecting(source, { left: 0, right: 3, top: 0, bottom: 3 })).toBe(true);
 
     // Touching source's bottom-right corner.
-    expect(isIntersecting(source, { left: 4, right: 6, top: 4, bottom: 6 })).toBe(true);
+    expect(isIntersecting(source, { left: 3, right: 6, top: 3, bottom: 6 })).toBe(true);
   });
 
-  test("returns false if rects are not touching", () => {
+  test("returns false if one rect does not intersect with another", () => {
     const rect1 = { left: 2, right: 4, top: 2, bottom: 4 };
-    const rect2 = { left: 2, right: 4, top: 5, bottom: 6 };
+    const rect2 = { left: 2, right: 4, top: 4, bottom: 6 };
     expect(isIntersecting(rect1, rect2)).toBe(false);
   });
 });


### PR DESCRIPTION
### Description

The test failed in main after merge due to a slight change in `isIntersecting` implementation which no longer considers intersections with area=0.

The PR fixes the test.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
