### PR TITLE
fix: Ignore fixed items with pointer-events: none for collisions check

### DIFF
--- a/src/internal/utils/dom.ts
+++ b/src/internal/utils/dom.ts
@@ -20,7 +20,8 @@ export function queryFixedRects(target: HTMLElement): readonly DOMRect[] {
     const computedStyle = getComputedStyle(element);
     const isDisplayed = computedStyle.display !== "none";
     const isFixedOrSticky = computedStyle.position === "fixed" || computedStyle.position === "sticky";
-    if (isDisplayed && isFixedOrSticky) {
+    const isPointerEventsAllowed = computedStyle.pointerEvents !== "none";
+    if (isDisplayed && isFixedOrSticky && isPointerEventsAllowed) {
       rects.push(element.getBoundingClientRect());
     }
   }


### PR DESCRIPTION
### Description

If there is a fixed overlay with `pointer-events: none` it should be ignored when evaluating collision checks.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
