### PR TITLE
feat: Make overlap detection based on draggable rect instead of pointer position

### DIFF
--- a/test/visual/drag-states.test.ts
+++ b/test/visual/drag-states.test.ts
@@ -195,15 +195,15 @@ test(
 test(
   "collisions disabled when item moves outside the board",
   setupTest("/index.html#/with-app-layout/integ", async (page) => {
-    await page.setWindowSize({ width: 2000, height: 800 });
+    await page.setWindowSize({ width: 2200, height: 800 });
 
-    // Moving item to the left but its center is still above the board.
+    // Moving item to the left but it still touches the board.
     await page.mouseDown(boardWrapper.findItemById("D").findDragHandle().toSelector());
-    await page.mouseMove(-150, 0);
+    await page.mouseMove(-250, 0);
     expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
 
-    // Moving item further to the left so that its center is outside the board.
-    await page.mouseMove(-50, 0);
+    // Moving item further to the left so that it leaves the board.
+    await page.mouseMove(-150, 0);
     expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
   })
 );


### PR DESCRIPTION
### Description

Now collisions detection is not prevented is the item is moved outside the board just slightly. It only counts when its center leaves the board.

Note: the visual regressions are failing because of an upstream update. Investigating separately.

### How has this been tested?

Added new integ test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
