### PR TITLE
fix: Prevent item resize below min size for pointer and keyboard

### DIFF
--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -32,11 +32,11 @@ const createDefaultWidget = (id: string) => ({
 
 export const demoWidgets: ItemWidgets = {
   D: {
-    definition: { defaultColumnSpan: 2, defaultRowSpan: 1 },
+    definition: { defaultColumnSpan: 2, defaultRowSpan: 4, minRowSpan: 4 },
     data: {
       title: "Demo widget",
       description: "Most minimal widget",
-      content: <DefaultContainer>Hello world!</DefaultContainer>,
+      content: <DefaultContainer>My minimal row span is 4.</DefaultContainer>,
     },
   },
   counter: {

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -108,7 +108,7 @@ export function InternalBoard<D>({ items, renderItem, onItemsChange, empty, i18n
         // If draggables can be of different types a check of some sort is required here.
         draggableItem: draggableItem as any,
         draggableElement,
-        collisionIds: !isBlocked(coordinates) ? collisionIds : [],
+        collisionIds: interactionType === "keyboard" || !isBlocked(coordinates) ? collisionIds : [],
       });
 
       autoScrollHandlers.addPointerEventHandlers();

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -8,6 +8,7 @@ import { DndPageObject } from "./dnd-page-object.js";
 
 const boardWrapper = createWrapper().findBoard();
 const itemsPaletteWrapper = createWrapper().findItemsPalette();
+const boardItemResizeHandle = (id: string) => boardWrapper.findItemById(id).findResizeHandle().toSelector();
 
 function makeQueryUrl(layout: string[][], palette: string[]) {
   const query = `layout=${JSON.stringify(layout)}&palette=${JSON.stringify(palette)}`;
@@ -174,6 +175,84 @@ test(
 
       await page.mouseMove(0, 900);
       await expect(page.getElementsCount(placeholderSelector)).resolves.toBe(14 * 4);
+    }
+  )
+);
+
+test(
+  "can't resize items below min size with pointer",
+  setupTest(
+    // X item has min columns = 2 and min rows = 4.
+    makeQueryUrl(
+      [
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+      ],
+      []
+    ),
+    async (page) => {
+      await page.mouseDown(boardWrapper.findItemById("X").findResizeHandle().toSelector());
+      await expect(page.getGrid()).resolves.toEqual([
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        [" ", " ", " ", " "],
+      ]);
+
+      await page.mouseMove(-500, -500);
+      await expect(page.getGrid()).resolves.toEqual([
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        [" ", " ", " ", " "],
+      ]);
+    }
+  )
+);
+
+test(
+  "can't resize items below min size with keyboard",
+  setupTest(
+    // X item has min columns = 2 and min rows = 4.
+    makeQueryUrl(
+      [
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+      ],
+      []
+    ),
+    async (page) => {
+      await page.focus(boardItemResizeHandle("X"));
+      await page.keys(["Enter"]);
+      await expect(page.getGrid()).resolves.toEqual([
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        ["X", "X", "X", " "],
+        [" ", " ", " ", " "],
+      ]);
+
+      await page.keys(["ArrowLeft"]);
+      await page.keys(["ArrowLeft"]);
+      await page.keys(["ArrowUp"]);
+      await page.keys(["ArrowUp"]);
+      await expect(page.getGrid()).resolves.toEqual([
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        [" ", " ", " ", " "],
+      ]);
     }
   )
 );


### PR DESCRIPTION
### Description

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

Added new integ tests.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
