### PR TITLE
resize window before test starts

### DIFF
--- a/test/setup-test.ts
+++ b/test/setup-test.ts
@@ -4,17 +4,17 @@
 import { BasePageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import useBrowser from "@cloudscape-design/browser-test-tools/use-browser";
 
+// Default window size to ensure 4-columns layout is used.
+const windowSize = { width: 1600, height: 800 };
+
 export function setupTest<P extends BasePageObject & { init?(): Promise<void> }>(
   url: string,
   PageClass: new (browser: WebdriverIO.Browser) => P,
   test: (page: P) => Promise<void>
 ) {
-  return useBrowser(async (browser) => {
+  return useBrowser(windowSize, async (browser) => {
     await browser.url(url);
     const page = new PageClass(browser);
-
-    // Default window size to ensure 4-columns layout is used.
-    await page.setWindowSize({ width: 1600, height: 800 });
     await page.waitForVisible("main");
 
     // Custom initialization.


### PR DESCRIPTION
### Description

This improves stability because page initially loads in the expected layout

Related links, issue #, if available: n/a

### How has this been tested?

PR build

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
