### PR TITLE
Keep default size when inserting items in restricted layouts

### DIFF
--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -14,7 +14,7 @@ import {
 } from "../internal/constants";
 import { useDragSubscription } from "../internal/dnd-controller/controller";
 import Grid from "../internal/grid";
-import { BoardItemDefinition, Direction, ItemId } from "../internal/interfaces";
+import { BoardItemDefinition, BoardItemDefinitionBase, Direction, ItemId } from "../internal/interfaces";
 import { ItemContainer, ItemContainerRef } from "../internal/item-container";
 import LiveRegion from "../internal/live-region";
 import { ScreenReaderGridNavigation } from "../internal/screenreader-grid-navigation";
@@ -132,7 +132,7 @@ export function InternalBoard<D>({
       // TODO: resolve any
       // The code only works assuming the board can take any draggable.
       // If draggables can be of different types a check of some sort is required here.
-      draggableItem: draggableItem as any,
+      draggableItem: draggableItem as BoardItemDefinitionBase<any>,
       draggableElement,
       collisionIds: interactionType === "keyboard" || isElementOverBoard(draggableElement) ? collisionIds : [],
     });

--- a/src/internal/utils/layout.ts
+++ b/src/internal/utils/layout.ts
@@ -1,19 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { COLUMNS_M, COLUMNS_XS, MIN_COL_SPAN, MIN_ROW_SPAN } from "../constants";
+import { getDefaultItemWidth } from "../../board/utils/layout";
+import { COLUMNS_DEFAULT, COLUMNS_M, COLUMNS_XS, MIN_COL_SPAN, MIN_ROW_SPAN } from "../constants";
 import { BoardItemDefinition, BoardItemDefinitionBase, GridLayout, GridLayoutItem, ItemId } from "../interfaces";
 import { LayoutShift } from "../layout-engine/interfaces";
 
 export function createItemsLayout(items: readonly BoardItemDefinition<unknown>[], columns: number): GridLayout {
   const layoutItems: GridLayoutItem[] = [];
-  const colAffordance = Array(columns).fill(-1);
+  const colAffordance = Array(COLUMNS_DEFAULT * 2).fill(-1);
 
   for (const { id, columnSpan, rowSpan, columnOffset, definition } of items) {
     const startCol = Math.min(columns - 1, columnOffset);
-    const normalizedColumnSpan = Math.max(
-      definition?.minColumnSpan ?? MIN_COL_SPAN,
-      Math.min(columns - startCol, getColumnSpanForColumns(columnSpan, columns))
+    const normalizedColumnSpan = Math.min(
+      columns - startCol,
+      Math.max(definition?.minColumnSpan ?? MIN_COL_SPAN, getColumnSpanForColumns(columnSpan, columns))
     );
     const allowedRowSpan = Math.max(MIN_ROW_SPAN, definition?.minRowSpan ?? MIN_ROW_SPAN, rowSpan);
 
@@ -92,9 +93,9 @@ export function exportItemsLayout<D>(
     // That means that the layout updates applied when in mobile or tablet layout are only partially applied.
     let columnOffset = x;
     let columnSpan = width;
-    if ((columns === COLUMNS_XS || columns === COLUMNS_M) && "columnOffset" in item && "columnSpan" in item) {
-      columnOffset = item.columnOffset;
-      columnSpan = item.columnSpan;
+    if (columns === COLUMNS_XS || columns === COLUMNS_M) {
+      columnOffset = "columnOffset" in item ? item.columnOffset : x;
+      columnSpan = "columnSpan" in item ? item.columnSpan : getDefaultItemWidth(item, COLUMNS_DEFAULT);
     }
 
     // Partial items update when a change is made in tablet layout.

--- a/test/functional/board-layout/keyboard-interactions.test.ts
+++ b/test/functional/board-layout/keyboard-interactions.test.ts
@@ -9,7 +9,7 @@ const boardWrapper = createWrapper().findBoard();
 const itemsPaletteWrapper = createWrapper().findItemsPalette();
 const boardItemDragHandle = (id: string) => boardWrapper.findItemById(id).findDragHandle().toSelector();
 const boardItemResizeHandle = (id: string) => boardWrapper.findItemById(id).findResizeHandle().toSelector();
-const paletteItemHandle = (id: string) => itemsPaletteWrapper.findItemById(id).findDragHandle().toSelector();
+const paletteItemDragHandle = (id: string) => itemsPaletteWrapper.findItemById(id).findDragHandle().toSelector();
 
 function makeQueryUrl(layout: string[][], palette: string[]) {
   const query = `layout=${JSON.stringify(layout)}&palette=${JSON.stringify(palette)}`;
@@ -129,7 +129,7 @@ describe("items inserted with keyboard", () => {
   test(
     "item insert can be submitted",
     setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
-      await page.focus(paletteItemHandle("I"));
+      await page.focus(paletteItemDragHandle("I"));
       await page.keys(["Enter"]);
 
       await page.keys(["ArrowLeft"]);
@@ -155,7 +155,7 @@ describe("items inserted with keyboard", () => {
   test(
     "item insert can be discarded",
     setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
-      await page.focus(paletteItemHandle("I"));
+      await page.focus(paletteItemDragHandle("I"));
       await page.keys(["Enter"]);
       await page.keys(["ArrowDown"]);
       await page.keys(["ArrowDown"]);

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -382,3 +382,30 @@ test(
     }
   )
 );
+
+test(
+  "always inserts item with default dimensions",
+  setupTest(
+    makeQueryUrl(
+      [],
+      // X item has min columns = 2 and min rows = 4.
+      ["X"]
+    ),
+    DndPageObject,
+    async (page) => {
+      await page.setWindowSize({ width: 800, height: 800 });
+      await page.focus(paletteItemDragHandle("X"));
+      await page.keys(["Enter"]);
+      await page.keys(["ArrowLeft"]);
+      await page.keys(["Enter"]);
+
+      await page.setWindowSize({ width: 1600, height: 800 });
+      await expect(page.getGrid(4)).resolves.toEqual([
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+        ["X", "X", " ", " "],
+      ]);
+    }
+  )
+);


### PR DESCRIPTION
### Description

When item is inserted in 1-col layout it should preserve original min and default width even if it is bigger than 1 so that when using 4-col it would take effect.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
