### PR TITLE
Hide screen-reader nav with clip-path

### DIFF
--- a/src/internal/screenreader-grid-navigation/styles.scss
+++ b/src/internal/screenreader-grid-navigation/styles.scss
@@ -1,7 +1,6 @@
 .screen-reader-navigation-hidden {
   position: absolute !important;
-  top: -9999px !important;
-  left: -9999px !important;
+  clip-path: circle(0);
 }
 .screen-reader-navigation-visible {
   position: fixed;


### PR DESCRIPTION
### Description

I noticed that having position absolute with `-9999px` offset no longer works with Chrome+VO. The clip-path approach works with Chrome+VO, Safari+VO, Chrome+NVDA and Firefox+NVDA.

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
