### PR TITLE
chore: Create a themeable source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,4 @@ jobs:
     uses: cloudscape-design/.github/.github/workflows/release.yml@main
     secrets: inherit
     with:
-      publish-packages: lib/components
+      publish-packages: lib/components,lib/components-themeable

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://cloudscape.design",
   "scripts": {
     "prebuild": "rm -rf lib dist .cache",
-    "build": "npm-run-all build:pkg --parallel build:src:* --parallel build:pages:*",
+    "build": "npm-run-all build:pkg --parallel build:src:* --parallel build:pages:* build:themeable",
     "lint": "eslint --ignore-path .gitignore --ext ts,tsx,js .",
     "prepare": "husky install",
     "test:unit": "vitest run --config vite.unit.config.js",
@@ -31,6 +31,7 @@
     "build:src:copy": "cp README.md lib/components/",
     "build:src:docs": "node scripts/docs.js",
     "build:src:environment": "node scripts/environment",
+    "build:themeable": "node scripts/themeable-source",
     "build:pages:vite": "vite build",
     "build:pages:tsc": "tsc -p pages/tsconfig.json"
   },

--- a/scripts/package-json.js
+++ b/scripts/package-json.js
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import fs from "node:fs";
-import { writeSourceFile } from "./utils.js";
+import { writeJSON } from "./utils.js";
 
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
 
 mainPackage();
+themablePackage();
 
 function mainPackage() {
   writeJSON("lib/components/package.json", {
@@ -15,6 +16,11 @@ function mainPackage() {
   });
 }
 
-function writeJSON(path, content) {
-  writeSourceFile(path, JSON.stringify(content, null, 2) + "\n");
+function themablePackage() {
+  writeJSON("lib/components-themeable/package.json", {
+    name: "@cloudscape-design/board-components-themeable",
+    version: pkg.version,
+    repository: pkg.repository,
+    homepage: pkg.homepage,
+  });
 }

--- a/scripts/themeable-source.js
+++ b/scripts/themeable-source.js
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execaSync } from "execa";
+const cwd = process.cwd();
+
+const targetDir = path.join(cwd, "./lib/components-themeable");
+const internalDir = path.join(targetDir, "internal");
+
+const stylesSourceDir = path.join(cwd, "./src/");
+const stylesTargetDir = path.join(internalDir, "/scss");
+
+const componentsSourceDir = path.join(cwd, "./lib/components");
+const componentsTargetDir = path.join(internalDir, "/template");
+
+function copyStyles() {
+  fs.mkdirSync(stylesTargetDir, { recursive: true });
+  execaSync("rsync", [
+    "--prune-empty-dirs",
+    "-a",
+    "--include",
+    "*/",
+    "--include",
+    "*.scss",
+    "--exclude",
+    "*",
+    stylesSourceDir,
+    stylesTargetDir,
+  ]);
+}
+
+function copyTemplate() {
+  fs.mkdirSync(componentsTargetDir, { recursive: true });
+  fs.cpSync(componentsSourceDir, componentsTargetDir, { recursive: true });
+}
+
+copyTemplate();
+copyStyles();

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -35,3 +35,7 @@ export function writeSourceFile(filepath, content) {
   fs.mkdirSync(path.dirname(filepath), { recursive: true });
   fs.writeFileSync(filepath, content);
 }
+
+export function writeJSON(path, content) {
+  writeSourceFile(path, JSON.stringify(content, null, 2) + "\n");
+}


### PR DESCRIPTION
### Description

Create a new utility package, `@cloudscape-design/board-components-themeable` to allow these components to be themed

Related links, issue #, if available: n/a

### How has this been tested?

No theming yet, only publishing the code to our staging CodeArtifact registry

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
