### PR TITLE
fix: Skip items rendering during user interaction

### DIFF
--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -272,7 +272,7 @@ export function InternalBoard<D>({
                     }}
                     item={item}
                     transform={transforms[item.id]}
-                    inTransition={!!layoutShift}
+                    inTransition={!!transition || !!removeTransition}
                     placed={true}
                     acquired={item.id === acquiredItem?.id}
                     getItemSize={() => ({
@@ -285,7 +285,7 @@ export function InternalBoard<D>({
                     })}
                     onKeyMove={onItemMove}
                   >
-                    {renderItem(item, { removeItem: () => removeItemAction(item) })}
+                    {() => renderItem(item, { removeItem: () => removeItemAction(item) })}
                   </ItemContainer>
                 );
               });

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -20,7 +20,7 @@ const defaultProps: ItemContainerProps = {
   transform: undefined,
   inTransition: false,
   getItemSize: () => ({ width: 1, minWidth: 1, maxWidth: 1, height: 1, minHeight: 1, maxHeight: 1 }),
-  children: <Item />,
+  children: () => <Item />,
 };
 
 function Item() {

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -370,7 +370,7 @@ function ItemContainerComponent(
 
   const isActive = (!!transition && !transition.isBorrowed) || !!acquired;
   const childrenRef = useRef<ReactNode>(null);
-  if (!inTransition) {
+  if (!inTransition || isActive) {
     childrenRef.current = children();
   }
 
@@ -398,7 +398,7 @@ function ItemContainerComponent(
             : null,
         }}
       >
-        {inTransition && !isActive ? childrenRef.current : children()}
+        {childrenRef.current}
       </ItemContext.Provider>
     </div>
   );

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -95,7 +95,7 @@ export interface ItemContainerProps {
     maxHeight: number;
   };
   onKeyMove?(direction: Direction): void;
-  children: ReactNode;
+  children: () => ReactNode;
 }
 
 export const ItemContainer = forwardRef(ItemContainerComponent);
@@ -368,6 +368,12 @@ function ItemContainerComponent(
     focusDragHandle: () => dragHandleRef.current?.focus(),
   }));
 
+  const isActive = (!!transition && !transition.isBorrowed) || !!acquired;
+  const childrenRef = useRef<ReactNode>(null);
+  if (!inTransition) {
+    childrenRef.current = children();
+  }
+
   return (
     <div
       ref={itemRef}
@@ -378,7 +384,7 @@ function ItemContainerComponent(
     >
       <ItemContext.Provider
         value={{
-          isActive: (!!transition && !transition.isBorrowed) || !!acquired,
+          isActive,
           dragHandle: {
             ref: dragHandleRef,
             onPointerDown: onDragHandlePointerDown,
@@ -392,7 +398,7 @@ function ItemContainerComponent(
             : null,
         }}
       >
-        {children}
+        {inTransition && !isActive ? childrenRef.current : children()}
       </ItemContext.Provider>
     </div>
   );

--- a/src/items-palette/__tests__/palette.test.tsx
+++ b/src/items-palette/__tests__/palette.test.tsx
@@ -14,8 +14,8 @@ afterEach(cleanup);
 vi.mock("../../../lib/components/internal/dnd-controller/controller");
 vi.mock("../../../lib/components/internal/item-container", () => ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ItemContainer: forwardRef(({ children }: { children: ReactNode }, ref: Ref<ItemContainerRef>) => (
-    <div>{children}</div>
+  ItemContainer: forwardRef(({ children }: { children: () => ReactNode }, ref: Ref<ItemContainerRef>) => (
+    <div>{children()}</div>
   )),
 }));
 

--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -110,9 +110,11 @@ export function InternalItemsPalette<D>({
                 return { width, minWidth: width, maxWidth: width, height, minHeight: height, maxHeight: height };
               }}
             >
-              {renderItem(item, {
-                showPreview: dropState?.id === item.id && dropState.isExpanded,
-              })}
+              {() =>
+                renderItem(item, {
+                  showPreview: dropState?.id === item.id && dropState.isExpanded,
+                })
+              }
             </ItemContainer>
           ))}
         </SpaceBetween>


### PR DESCRIPTION
### Description

During user interaction the board constantly re-renders and causes items to re-render as well. This leads to performance issues when items have "heavy" content. As we do not expect items to re-render during the user interaction the item content can be cached with an exception of the target item which content might need to adjust when resizing.

### How has this been tested?

Manual checks to ensure the inactive items do not re-render during user interaction.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
