### PR TITLE
fix: Hide table sticky scrollbars during interaction

### DIFF
--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -113,6 +113,8 @@ export function InternalBoard<D>({
   }
 
   useDragSubscription("start", ({ operation, interactionType, draggableItem, collisionRect, collisionIds }) => {
+    document.body.setAttribute("data-awsui-hide-sticky-scrollbar", "true");
+
     dispatch({
       type: "init",
       operation,
@@ -139,6 +141,8 @@ export function InternalBoard<D>({
   });
 
   useDragSubscription("submit", () => {
+    document.body.removeAttribute("data-awsui-hide-sticky-scrollbar");
+
     dispatch({ type: "submit" });
 
     autoScrollHandlers.removePointerEventHandlers();
@@ -165,6 +169,8 @@ export function InternalBoard<D>({
   });
 
   useDragSubscription("discard", () => {
+    document.body.removeAttribute("data-awsui-hide-sticky-scrollbar");
+
     dispatch({ type: "discard" });
 
     autoScrollHandlers.removePointerEventHandlers();


### PR DESCRIPTION
### Description

Fixing table sticky scrollbars being off when moving items having a table inside. Requires https://github.com/cloudscape-design/components/pull/1056.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
