### PR TITLE
chore: Update board item focus outline for active state

### DIFF
--- a/src/board-item/__tests__/board-item-wrapper.tsx
+++ b/src/board-item/__tests__/board-item-wrapper.tsx
@@ -12,10 +12,12 @@ export function ItemContextWrapper({ children }: { children: ReactNode }) {
           ref: { current: null },
           onPointerDown: () => {},
           onKeyDown: () => {},
+          isActive: false,
         },
         resizeHandle: {
           onPointerDown: () => {},
           onKeyDown: () => {},
+          isActive: false,
         },
       }}
     >

--- a/src/board-item/internal.tsx
+++ b/src/board-item/internal.tsx
@@ -45,6 +45,7 @@ export function InternalBoardItem({
                 ariaDescribedBy={dragHandleAriaDescribedBy}
                 onPointerDown={dragHandle.onPointerDown}
                 onKeyDown={dragHandle.onKeyDown}
+                isActive={dragHandle.isActive}
               />
             }
             settings={settings}
@@ -65,6 +66,7 @@ export function InternalBoardItem({
             ariaDescribedBy={resizeHandleAriaDescribedBy}
             onPointerDown={resizeHandle.onPointerDown}
             onKeyDown={resizeHandle.onKeyDown}
+            isActive={resizeHandle.isActive}
           />
         </div>
       )}

--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -1,5 +1,26 @@
 @use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
-@use "../internal/handle/styles.scss" as handle;
+
+@mixin focus-highlight($gutter: 4px, $border-radius: cs.$border-radius-control-default-focus-ring) {
+  position: relative;
+  box-sizing: border-box;
+  outline: none;
+  & {
+    outline: 2px dotted transparent;
+    outline-offset: calc($gutter - 1px);
+  }
+  &::before {
+    content: " ";
+    display: block;
+    position: absolute;
+    box-sizing: border-box;
+    left: calc(-1 * #{$gutter});
+    top: calc(-1 * #{$gutter});
+    width: calc(100% + 2 * #{$gutter});
+    height: calc(100% + 2 * #{$gutter});
+    border-radius: $border-radius;
+    border: 2px solid cs.$color-border-item-focused;
+  }
+}
 
 .root {
   display: contents;
@@ -10,7 +31,7 @@
   box-shadow: cs.$shadow-container-active;
 
   :global([data-awsui-focus-visible]) & {
-    @include handle.focus-highlight(0px, cs.$border-radius-container);
+    @include focus-highlight(0px, cs.$border-radius-container);
   }
 }
 

--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -1,4 +1,5 @@
 @use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
+@use "../internal/handle/styles.scss" as handle;
 
 .root {
   display: contents;
@@ -7,6 +8,10 @@
 /* TODO: use container API instead of styles override */
 .container-override.active {
   box-shadow: cs.$shadow-container-active;
+
+  :global([data-awsui-focus-visible]) & {
+    @include handle.focus-highlight(0px, cs.$border-radius-container);
+  }
 }
 
 .header {

--- a/src/board/__tests__/board.test.tsx
+++ b/src/board/__tests__/board.test.tsx
@@ -6,6 +6,8 @@ import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import Board, { BoardProps } from "../../../lib/components/board";
 import boardStyles from "../../../lib/components/board/styles.css.js";
 import BoardItem from "../../../lib/components/board-item";
+import dragHandleStyles from "../../../lib/components/internal/drag-handle/styles.css.js";
+import resizeHandleStyles from "../../../lib/components/internal/resize-handle/styles.css.js";
 import createWrapper from "../../../lib/components/test-utils/dom";
 
 interface ItemData {
@@ -160,5 +162,63 @@ describe("Board", () => {
     // Release pointer and check that the class is not set
     fireEvent(window, new MouseEvent("pointerup", { bubbles: true }));
     expect(container.ownerDocument.body).not.toHaveClass(resizeClass);
+  });
+
+  test("sets active state for drag handle", () => {
+    render(
+      <Board
+        items={[
+          { id: "1", data: { title: "Item 1" } },
+          { id: "2", data: { title: "Item 2" } },
+        ]}
+        renderItem={(item) => <BoardItem i18nStrings={itemI18nStrings}>{item.data.title}</BoardItem>}
+        onItemsChange={() => undefined}
+        i18nStrings={i18nStrings}
+        empty="No items"
+      />
+    );
+
+    const dragHandle = createWrapper().findBoardItem()!.findDragHandle()!.getElement();
+    const resizeHandle = createWrapper().findBoardItem()!.findResizeHandle()!.getElement();
+
+    expect(dragHandle).not.toHaveClass(dragHandleStyles.active);
+
+    // Start operation
+    fireEvent(dragHandle, new MouseEvent("pointerdown", { bubbles: true }));
+    expect(dragHandle).toHaveClass(dragHandleStyles.active);
+    expect(resizeHandle).not.toHaveClass(dragHandleStyles.active);
+
+    // End operation
+    fireEvent(window, new MouseEvent("pointerup", { bubbles: true }));
+    expect(dragHandle).not.toHaveClass(dragHandleStyles.active);
+  });
+
+  test("sets active state for resize handle", () => {
+    render(
+      <Board
+        items={[
+          { id: "1", data: { title: "Item 1" } },
+          { id: "2", data: { title: "Item 2" } },
+        ]}
+        renderItem={(item) => <BoardItem i18nStrings={itemI18nStrings}>{item.data.title}</BoardItem>}
+        onItemsChange={() => undefined}
+        i18nStrings={i18nStrings}
+        empty="No items"
+      />
+    );
+
+    const dragHandle = createWrapper().findBoardItem()!.findDragHandle()!.getElement();
+    const resizeHandle = createWrapper().findBoardItem()!.findResizeHandle()!.getElement();
+
+    expect(resizeHandle).not.toHaveClass(resizeHandleStyles.active);
+
+    // Start operation
+    fireEvent(resizeHandle, new MouseEvent("pointerdown", { bubbles: true }));
+    expect(resizeHandle).toHaveClass(resizeHandleStyles.active);
+    expect(dragHandle).not.toHaveClass(resizeHandleStyles.active);
+
+    // End operation
+    fireEvent(window, new MouseEvent("pointerup", { bubbles: true }));
+    expect(resizeHandle).not.toHaveClass(resizeHandleStyles.active);
   });
 });

--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Icon } from "@cloudscape-design/components";
+import clsx from "clsx";
 import { ForwardedRef, KeyboardEvent, PointerEvent, forwardRef } from "react";
 
 import Handle from "../handle";
@@ -11,16 +12,17 @@ export interface DragHandleProps {
   ariaDescribedBy: string;
   onPointerDown: (event: PointerEvent) => void;
   onKeyDown: (event: KeyboardEvent) => void;
+  isActive: boolean;
 }
 
 function DragHandle(
-  { ariaLabelledBy, ariaDescribedBy, onPointerDown, onKeyDown }: DragHandleProps,
+  { ariaLabelledBy, ariaDescribedBy, onPointerDown, onKeyDown, isActive }: DragHandleProps,
   ref: ForwardedRef<HTMLButtonElement>
 ) {
   return (
     <Handle
       ref={ref}
-      className={styles.handle}
+      className={clsx(styles.handle, isActive && styles.active)}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
       onPointerDown={onPointerDown}

--- a/src/internal/drag-handle/styles.scss
+++ b/src/internal/drag-handle/styles.scss
@@ -5,3 +5,7 @@
 .handle:active {
   cursor: grabbing;
 }
+
+.active {
+  outline: none;
+}

--- a/src/internal/handle/styles.scss
+++ b/src/internal/handle/styles.scss
@@ -1,27 +1,5 @@
 @use "../../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
 
-@mixin focus-highlight($gutter: 4px, $border-radius: cs.$border-radius-control-default-focus-ring) {
-  position: relative;
-  box-sizing: border-box;
-  outline: none;
-  & {
-    outline: 2px dotted transparent;
-    outline-offset: calc($gutter - 1px);
-  }
-  &::before {
-    content: " ";
-    display: block;
-    position: absolute;
-    box-sizing: border-box;
-    left: calc(-1 * #{$gutter});
-    top: calc(-1 * #{$gutter});
-    width: calc(100% + 2 * #{$gutter});
-    height: calc(100% + 2 * #{$gutter});
-    border-radius: $border-radius;
-    border: 2px solid cs.$color-border-item-focused;
-  }
-}
-
 .handle {
   appearance: none;
   background: transparent;

--- a/src/internal/handle/styles.scss
+++ b/src/internal/handle/styles.scss
@@ -17,7 +17,7 @@
     top: calc(-1 * #{$gutter});
     width: calc(100% + 2 * #{$gutter});
     height: calc(100% + 2 * #{$gutter});
-    border-radius: cs.$border-radius-control-default-focus-ring;
+    border-radius: $border-radius;
     border: 2px solid cs.$color-border-item-focused;
   }
 }
@@ -32,9 +32,5 @@
 
   &:hover {
     color: cs.$color-text-interactive-hover;
-  }
-
-  &:focus-visible {
-    @include focus-highlight();
   }
 }

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -43,10 +43,12 @@ interface ItemContextType {
     ref: RefObject<HTMLButtonElement>;
     onPointerDown(event: ReactPointerEvent): void;
     onKeyDown(event: KeyboardEvent): void;
+    isActive: boolean;
   };
   resizeHandle: null | {
     onPointerDown(event: ReactPointerEvent): void;
     onKeyDown(event: KeyboardEvent): void;
+    isActive: boolean;
   };
 }
 
@@ -389,11 +391,13 @@ function ItemContainerComponent(
             ref: dragHandleRef,
             onPointerDown: onDragHandlePointerDown,
             onKeyDown: onDragHandleKeyDown,
+            isActive: isActive && transition?.operation === "reorder",
           },
           resizeHandle: placed
             ? {
                 onPointerDown: onResizeHandlePointerDown,
                 onKeyDown: onResizeHandleKeyDown,
+                isActive: isActive && transition?.operation === "resize",
               }
             : null,
         }}

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Icon } from "@cloudscape-design/components";
+import clsx from "clsx";
 import { KeyboardEvent, PointerEvent } from "react";
 import Handle from "../handle";
 import styles from "./styles.css.js";
@@ -10,12 +11,19 @@ export interface ResizeHandleProps {
   ariaDescribedBy: string;
   onPointerDown: (event: PointerEvent) => void;
   onKeyDown: (event: KeyboardEvent) => void;
+  isActive: boolean;
 }
 
-export default function ResizeHandle({ ariaLabelledBy, ariaDescribedBy, onPointerDown, onKeyDown }: ResizeHandleProps) {
+export default function ResizeHandle({
+  ariaLabelledBy,
+  ariaDescribedBy,
+  onPointerDown,
+  onKeyDown,
+  isActive,
+}: ResizeHandleProps) {
   return (
     <Handle
-      className={styles.handle}
+      className={clsx(styles.handle, isActive && styles.active)}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
       onPointerDown={onPointerDown}

--- a/src/internal/resize-handle/styles.scss
+++ b/src/internal/resize-handle/styles.scss
@@ -1,3 +1,7 @@
 .handle {
   cursor: nwse-resize;
 }
+
+.active {
+  outline: none;
+}


### PR DESCRIPTION
### Description

This change updates the visual affordance of the active focus state for reorder and resize operations. Instead of keeping the focus outline on the reorder or resize handle button, we now display a blue outline around the container to indicate the active reorder/resize operation.

Related links, issue #, if available: AWSUI-20818

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
