### PR TITLE
refactor: Make keyboard transitions for drag- and resize not depend on DOM

### DIFF
--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -123,7 +123,7 @@ export function InternalBoard<D>({
       // If draggables can be of different types a check of some sort is required here.
       draggableItem: draggableItem as BoardItemDefinitionBase<any>,
       draggableRect: collisionRect,
-      collisionIds: interactionType === "keyboard" || isElementOverBoard(collisionRect) ? collisionIds : [],
+      collisionIds: interactionType === "pointer" && isElementOverBoard(collisionRect) ? collisionIds : [],
     });
 
     autoScrollHandlers.addPointerEventHandlers();
@@ -134,7 +134,7 @@ export function InternalBoard<D>({
   useDragSubscription("update", ({ interactionType, collisionIds, positionOffset, collisionRect }) => {
     dispatch({
       type: "update-with-pointer",
-      collisionIds: interactionType === "keyboard" || isElementOverBoard(collisionRect) ? collisionIds : [],
+      collisionIds: interactionType === "pointer" && isElementOverBoard(collisionRect) ? collisionIds : [],
       positionOffset,
       draggableRect: collisionRect,
     });

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -115,15 +115,24 @@ function initTransition<D>({
 
   const placeholdersLayout = getLayoutPlaceholders(transition);
 
-  const itemBelongsToBoard = itemsLayout.items.find((it) => it.id === draggableItem.id);
-  const collisionRect = getHoveredRect(collisionIds, placeholdersLayout.items);
-  const appendPath = operation === "resize" ? appendResizePath : appendMovePath;
-  const path = itemBelongsToBoard ? appendPath([], collisionRect) : [];
+  const layoutItem = itemsLayout.items.find((it) => it.id === draggableItem.id);
+
+  let path: Position[] = [];
+  if (interactionType === "pointer" || operation === "insert") {
+    const collisionRect = getHoveredRect(collisionIds, placeholdersLayout.items);
+    const appendPath = operation === "resize" ? appendResizePath : appendMovePath;
+    path = layoutItem ? appendPath([], collisionRect) : [];
+  } else if (layoutItem) {
+    path =
+      operation === "resize"
+        ? [new Position({ x: layoutItem.x + layoutItem.width, y: layoutItem.y + layoutItem.height })]
+        : [new Position({ x: layoutItem.x, y: layoutItem.y })];
+  }
 
   return {
     transition: { ...transition, path },
     removeTransition: null,
-    announcement: itemBelongsToBoard ? { type: "dnd-started", item: draggableItem, operation } : null,
+    announcement: layoutItem ? { type: "dnd-started", item: draggableItem, operation } : null,
   };
 }
 


### PR DESCRIPTION
### Description

While the pointer-based D&D requires position measurements and is exceptionally tricky to test in JSDOM, the keyboard-based operations can be made testable. The current changes makes it possible to test basic keyboard operations for drag- and resize.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
