### PR TITLE
fix: Call renderItem in palette when dragging item from palette to board

### DIFF
--- a/src/board/interfaces.ts
+++ b/src/board/interfaces.ts
@@ -168,6 +168,7 @@ export interface Transition<D> {
   collisionIds: Set<ItemId>;
   layoutShift: null | LayoutShift;
   path: readonly Position[];
+  acquiredItemElement?: ReactNode;
 }
 
 export interface RemoveTransition<D> {

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -54,6 +54,7 @@ export function InternalBoard<D>({
   const removeTransition = transitionState.removeTransition;
   const transitionAnnouncement = transitionState.announcement;
   const acquiredItem = transition?.acquiredItem ?? null;
+  const acquiredItemElement = transition?.acquiredItemElement;
 
   // Using cached columns from transition to ensure no unexpected changes in the process.
   const columns = transition ? transition.itemsLayout.columns : currentColumns;
@@ -180,7 +181,7 @@ export function InternalBoard<D>({
     autoScrollHandlers.removePointerEventHandlers();
   });
 
-  useDragSubscription("acquire", ({ droppableId, draggableItem }) => {
+  useDragSubscription("acquire", ({ droppableId, draggableItem, acquiredItemElement }) => {
     const placeholder = placeholdersLayout.items.find((it) => it.id === droppableId);
 
     // If missing then it does not belong to this board.
@@ -192,6 +193,7 @@ export function InternalBoard<D>({
       type: "acquire-item",
       position: new Position({ x: placeholder.x, y: placeholder.y }),
       layoutElement: containerAccessRef.current!,
+      acquiredItemElement: acquiredItemElement,
     });
 
     focusNextRenderIdRef.current = draggableItem.id;
@@ -295,7 +297,9 @@ export function InternalBoard<D>({
                     })}
                     onKeyMove={onItemMove}
                   >
-                    {() => renderItem(item, { removeItem: () => removeItemAction(item) })}
+                    {item.id === acquiredItem?.id && acquiredItemElement
+                      ? () => acquiredItemElement
+                      : () => renderItem(item, { removeItem: () => removeItemAction(item) })}
                   </ItemContainer>
                 );
               });

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Dispatch, useReducer } from "react";
+import { Dispatch, ReactNode, useReducer } from "react";
 import { InteractionType, Operation } from "../internal/dnd-controller/controller";
 import { BoardItemDefinitionBase, Direction, GridLayout, ItemId, Rect } from "../internal/interfaces";
 import { LayoutEngine } from "../internal/layout-engine/engine";
@@ -63,6 +63,7 @@ interface AcquireItemAction {
   type: "acquire-item";
   position: Position;
   layoutElement: HTMLElement;
+  acquiredItemElement?: ReactNode;
 }
 
 export function useTransition<D>(): [TransitionState<D>, Dispatch<Action<D>>] {
@@ -309,7 +310,7 @@ function updateTransitionWithKeyboardEvent<D>(
 
 function acquireTransitionItem<D>(
   state: TransitionState<D>,
-  { position, layoutElement }: AcquireItemAction
+  { position, layoutElement, acquiredItemElement }: AcquireItemAction
 ): TransitionState<D> {
   const { transition } = state;
 
@@ -335,7 +336,14 @@ function acquireTransitionItem<D>(
   // The columnOffset, columnSpan and rowSpan are of no use as of being overridden by the layout shift.
   const acquiredItem = { ...transition.draggableItem, columnOffset: 0, columnSpan: 1, rowSpan: 1 };
 
-  const nextTransition: Transition<D> = { ...transition, collisionIds: new Set(), layoutShift, path, acquiredItem };
+  const nextTransition: Transition<D> = {
+    ...transition,
+    collisionIds: new Set(),
+    layoutShift,
+    path,
+    acquiredItem,
+    acquiredItemElement,
+  };
   return {
     transition: nextTransition,
     removeTransition: null,

--- a/src/internal/dnd-controller/controller.ts
+++ b/src/internal/dnd-controller/controller.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useEffect } from "react";
+import { ReactNode, useEffect } from "react";
 import { BoardItemDefinitionBase, ItemId, Rect } from "../interfaces";
 import { Coordinates } from "../utils/coordinates";
 import { EventEmitter } from "./event-emitter";
@@ -41,6 +41,7 @@ export interface Droppable {
 interface AcquireData {
   droppableId: ItemId;
   draggableItem: Item;
+  acquiredItemElement?: ReactNode;
 }
 
 export interface DragAndDropEvents {
@@ -99,11 +100,11 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
   /**
    * Issues an "acquire" event to notify the current transition draggable is acquired by the given droppable.
    */
-  public acquire(droppableId: ItemId) {
+  public acquire(droppableId: ItemId, acquiredItemElement?: ReactNode) {
     if (!this.transition) {
       throw new Error("Invariant violation: no transition present for acquire.");
     }
-    this.emit("acquire", { droppableId, draggableItem: this.transition.draggableItem });
+    this.emit("acquire", { droppableId, draggableItem: this.transition.draggableItem, acquiredItemElement });
   }
 
   /**
@@ -186,8 +187,8 @@ export function useDraggable({
     discardTransition() {
       controller.discard();
     },
-    acquire(droppableId: ItemId) {
-      controller.acquire(droppableId);
+    acquire(droppableId: ItemId, acquiredItemElement?: ReactNode) {
+      controller.acquire(droppableId, acquiredItemElement);
     },
     getDroppables() {
       return controller.getDroppables();

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -239,7 +239,7 @@ function ItemContainerComponent(
     }
 
     // Notify the respective droppable of the intention to insert the item in it.
-    draggableApi.acquire(nextDroppable);
+    draggableApi.acquire(nextDroppable, childrenRef.current);
   }
 
   function onHandleKeyDown(operation: "drag" | "resize", event: KeyboardEvent) {

--- a/test/functional/board-layout/keyboard-interactions.test.ts
+++ b/test/functional/board-layout/keyboard-interactions.test.ts
@@ -164,4 +164,16 @@ describe("items inserted with keyboard", () => {
       ]);
     })
   );
+
+  test(
+    "item to be inserted with keyboard has preview content",
+    setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
+      await page.focus(paletteItemDragHandle("I"));
+      await page.keys(["Enter"]);
+      await page.keys(["ArrowLeft"]);
+      await expect(page.getText(boardWrapper.find(`[data-item-id="I"]`).toSelector())).resolves.toBe(
+        "Widget I\nEmpty widget"
+      );
+    })
+  );
 });


### PR DESCRIPTION
### Description

When the item is not yet inserted the renderItem for it should only be called from the palette, not the board, as it is not yet inserted into the board (the operation can be cancelled). 

Related links, issue #AWSUI-21420

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
