### PR TITLE
fix: Submit keyboard transitions when mouse interactions happen

### DIFF
--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -196,6 +196,18 @@ function ItemContainerComponent(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item.id, transitionInteractionType, transitionItemId]);
 
+  useEffect(() => {
+    if (transitionInteractionType === "keyboard" && transitionItemId === item.id) {
+      const onPointerDown = () => draggableApi.submitTransition();
+      window.addEventListener("pointerdown", onPointerDown, true);
+      return () => {
+        window.removeEventListener("pointerdown", onPointerDown, true);
+      };
+    }
+    // draggableApi is not expected to change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item.id, transitionInteractionType, transitionItemId]);
+
   function onKeyboardTransitionToggle(operation: "drag" | "resize") {
     // The acquired item is a copy and does not have the transition state.
     // However, pressing "Space" or "Enter" on the acquired item must submit the active transition.
@@ -279,11 +291,11 @@ function ItemContainerComponent(
   }
 
   function onBlur() {
-    // When drag- or resize handle loses focus the transition must be discarded with two exceptions:
+    // When drag- or resize handle loses focus the transition must be submitted with two exceptions:
     // 1. If the last interaction is not "keyboard" (the user clicked on another handle issuing a new transition);
     // 2. If the item is borrowed (in that case the focus moves to the acquired item which is expected).
     if (transition && transition.interactionType === "keyboard" && !transition.isBorrowed) {
-      draggableApi.discardTransition();
+      draggableApi.submitTransition();
     }
   }
 

--- a/test/functional/board-layout/keyboard-interactions.test.ts
+++ b/test/functional/board-layout/keyboard-interactions.test.ts
@@ -49,6 +49,22 @@ describe("items reordered with keyboard", () => {
       ]);
     })
   );
+
+  test(
+    "item keyboard move automatically submits after leaving focus",
+    setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
+      await page.focus(boardItemDragHandle("A"));
+      await page.keys(["Enter"]);
+      await page.keys(["ArrowRight"]);
+      await page.keys(["Tab"]);
+      await expect(page.getGrid()).resolves.toEqual([
+        ["B", "A", "C", "D"],
+        ["B", "A", "C", "D"],
+        ["E", "F", "G", "H"],
+        ["E", "F", "G", "H"],
+      ]);
+    })
+  );
 });
 
 describe("items resized with keyboard", () => {
@@ -143,6 +159,27 @@ describe("items inserted with keyboard", () => {
         ["E", "F", "G", "H"],
         [" ", " ", " ", "I"],
         [" ", " ", " ", "I"],
+      ]);
+    })
+  );
+
+  test(
+    "item insert with keyboard automatically submits after mouse interaction",
+    setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
+      await page.focus(paletteItemDragHandle("I"));
+      await page.keys(["Enter"]);
+      await page.keys(["ArrowLeft"]);
+
+      // click anywhere on the page to submit the current transition, for example on another item handle
+      await page.click(boardItemResizeHandle("A"));
+
+      await expect(page.getGrid()).resolves.toEqual([
+        ["A", "B", "D", "I"],
+        ["A", "B", "D", "I"],
+        ["E", "F", "C", "H"],
+        ["E", "F", "C", "H"],
+        [" ", " ", "G", " "],
+        [" ", " ", "G", " "],
       ]);
     })
   );


### PR DESCRIPTION
### Description

Dragging an item with mouse begins a new transition. If there was another keyboard move in progress (user moved the item with arrow keys but did not press "Enter" to finish the move), it thrown an exception.

The new approach resolves it by forcefully submitting the pending keyboard move.

Related links, issue #, if available: AWSUI-21437

### How has this been tested?

* Locally
* Added new tests

---

P.S. the other, "start using keyboard without releasing mouse" conflict is still possible, but less likely to happen, so I am not going to handle that. At least not until real use-case shows up

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
