### PR TITLE
fix: Hide borrowed items

### DIFF
--- a/src/internal/item-container/styles.scss
+++ b/src/internal/item-container/styles.scss
@@ -25,5 +25,5 @@
   position: absolute;
 }
 .borrowed {
-  opacity: 0.5;
+  display: none;
 }


### PR DESCRIPTION
### Description

Hide borrowed items instead of dimming. 

Borrowed item – it is an item moved to the board using keyboard (keyboard navigation renders a copy of that item on the board instead). 

Mirroring the mouse drag logic, the item should completely disappear from the origin

Related links, issue #, if available: AWSUI-21437

### How has this been tested?

Locally

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
