### PR TITLE
chore: Align VR container handle with new header updates

### DIFF
--- a/src/board-item/header.tsx
+++ b/src/board-item/header.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
 import { ReactNode } from "react";
+import { useVisualRefresh } from "../internal/base-component/use-visual-refresh.js";
 import styles from "./styles.css.js";
 
 export interface WidgetContainerHeaderProps {
@@ -11,8 +12,9 @@ export interface WidgetContainerHeaderProps {
 }
 
 export default function WidgetContainerHeader({ handle, children, settings }: WidgetContainerHeaderProps) {
+  const isVisualRefresh = useVisualRefresh();
   return (
-    <div className={styles.header}>
+    <div className={clsx(styles.header, isVisualRefresh && styles.refresh)}>
       <div className={clsx(styles.fixed, styles.handle)}>{handle}</div>
       <div className={clsx(styles.flexible, styles["header-content"])}>{children}</div>
       {settings ? <div className={clsx(styles.fixed, styles.settings)}>{settings}</div> : null}

--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -47,6 +47,9 @@
 
 .handle {
   margin-top: calc(cs.$space-scaled-xxs + 1px);
+  .refresh > & {
+    margin-top: calc(cs.$space-static-xxxs + 1px);
+  }
 }
 
 .header-content {
@@ -56,6 +59,9 @@
 .settings {
   margin-top: calc(cs.$space-scaled-xxxs + 1px);
   margin-left: cs.$space-static-xs;
+  .refresh > & {
+    margin-top: 0px;
+  }
 }
 
 .fixed {


### PR DESCRIPTION
### Description

This change is needed  for components [#1317](https://github.com/cloudscape-design/components/pull/1317), which reduces the height of heading elements. This makes it so the handle remains aligned with the container headers

Related links, issue #, if available: [#1317](https://github.com/cloudscape-design/components/pull/1317)

### How has this been tested?

Ran through my dev pipeline

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
