### PR TITLE
fix: Render dragged item using portals to prevent z-index issues

### DIFF
--- a/pages/with-app-layout/widgets-board.tsx
+++ b/pages/with-app-layout/widgets-board.tsx
@@ -51,15 +51,17 @@ export function WidgetsBoard({ loading, widgets, onWidgetsChange }: WidgetsBoard
             {item.data.content}
           </BoardItem>
 
-          <DeleteConfirmationModal
-            title={item.data.title}
-            visible={deleteConfirmation === item.id}
-            onDismiss={() => setDeleteConfirmation(null)}
-            onConfirm={() => {
-              actions.removeItem();
-              setDeleteConfirmation(null);
-            }}
-          />
+          {deleteConfirmation === item.id && (
+            <DeleteConfirmationModal
+              title={item.data.title}
+              visible={true}
+              onDismiss={() => setDeleteConfirmation(null)}
+              onConfirm={() => {
+                actions.removeItem();
+                setDeleteConfirmation(null);
+              }}
+            />
+          )}
         </>
       )}
     />

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -7,6 +7,7 @@ import { InternalBaseComponentProps } from "../internal/base-component/use-base-
 import { useContainerColumns } from "../internal/breakpoints";
 import { TRANSITION_DURATION_MS } from "../internal/constants";
 import { useDragSubscription } from "../internal/dnd-controller/controller";
+import { useGlobalDragStateStyles } from "../internal/global-drag-state-styles";
 import Grid from "../internal/grid";
 import { BoardItemDefinition, BoardItemDefinitionBase, Direction, ItemId, Rect } from "../internal/interfaces";
 import { ItemContainer, ItemContainerRef } from "../internal/item-container";
@@ -46,6 +47,8 @@ export function InternalBoard<D>({
   const [currentColumns, containerQueryRef] = useContainerColumns();
   const containerRef = useMergeRefs(containerAccessRef, containerQueryRef);
   const itemContainerRef = useRef<{ [id: ItemId]: ItemContainerRef }>({});
+
+  useGlobalDragStateStyles();
 
   const autoScrollHandlers = useAutoScroll();
 
@@ -132,8 +135,6 @@ export function InternalBoard<D>({
     });
 
     autoScrollHandlers.addPointerEventHandlers();
-
-    document.body.classList.add(styles[`current-operation-${operation}`]);
   });
 
   useDragSubscription("update", ({ interactionType, collisionIds, positionOffset, collisionRect }) => {
@@ -149,8 +150,6 @@ export function InternalBoard<D>({
     dispatch({ type: "submit" });
 
     autoScrollHandlers.removePointerEventHandlers();
-
-    document.body.classList.remove(styles["current-operation-reorder"], styles["current-operation-resize"]);
 
     if (!transition) {
       throw new Error("Invariant violation: no transition.");
@@ -175,8 +174,6 @@ export function InternalBoard<D>({
 
   useDragSubscription("discard", () => {
     dispatch({ type: "discard" });
-
-    document.body.classList.remove(styles["current-operation-reorder"], styles["current-operation-resize"]);
 
     autoScrollHandlers.removePointerEventHandlers();
   });

--- a/src/board/styles.scss
+++ b/src/board/styles.scss
@@ -23,11 +23,3 @@
   display: flex;
   justify-content: center;
 }
-
-.current-operation-reorder {
-  cursor: grabbing;
-}
-
-.current-operation-resize {
-  cursor: nwse-resize;
-}

--- a/src/internal/global-drag-state-styles/index.ts
+++ b/src/internal/global-drag-state-styles/index.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { DragAndDropData, useDragSubscription } from "../dnd-controller/controller";
+import styles from "./styles.css.js";
+
+function assertNever(value: never) {
+  throw new Error("Unexpected value: " + value);
+}
+
+function setup({ operation, interactionType }: DragAndDropData) {
+  switch (operation) {
+    case "insert":
+    case "reorder":
+      document.body.classList.add(styles["show-grab-cursor"]);
+      break;
+    case "resize":
+      document.body.classList.add(styles["show-resize-cursor"]);
+      break;
+    default:
+      // there will be a type error if not all operation types are handled
+      assertNever(operation);
+  }
+
+  if (interactionType === "pointer") {
+    document.body.classList.add(styles["disable-selection"]);
+  }
+}
+
+function teardown() {
+  document.body.classList.remove(styles["show-grab-cursor"], styles["show-resize-cursor"], styles["disable-selection"]);
+}
+
+export function useGlobalDragStateStyles() {
+  useDragSubscription("start", setup);
+  useDragSubscription("discard", teardown);
+  useDragSubscription("submit", teardown);
+}

--- a/src/internal/global-drag-state-styles/styles.scss
+++ b/src/internal/global-drag-state-styles/styles.scss
@@ -1,0 +1,11 @@
+.show-grab-cursor * {
+  cursor: grabbing;
+}
+
+.show-resize-cursor * {
+  cursor: nwse-resize;
+}
+
+.disable-selection * {
+  user-select: none;
+}

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
-import { mockDraggable } from "../../../../lib/components/internal/dnd-controller/__mocks__/controller";
+import { mockController, mockDraggable } from "../../../../lib/components/internal/dnd-controller/__mocks__/controller";
+import { DragAndDropData } from "../../../../lib/components/internal/dnd-controller/controller";
 import { ItemContainer, ItemContainerProps, useItemContext } from "../../../../lib/components/internal/item-container";
 import { Coordinates } from "../../../../lib/components/internal/utils/coordinates";
 
@@ -59,4 +60,23 @@ test("starts resize transition when resize handle is clicked", () => {
   const { getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
   getByTestId("resize-handle").click();
   expect(mockDraggable.start).toBeCalledWith("resize", "pointer", expect.any(Coordinates));
+});
+
+test("renders in portal when item in reorder state by a pointer", () => {
+  const { container, getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
+  expect(container).toContainElement(getByTestId("drag-handle"));
+  act(() => {
+    mockController.start({
+      interactionType: "pointer",
+      operation: "reorder",
+      draggableItem: defaultProps.item,
+      collisionRect: { top: 0, bottom: 0, left: 0, right: 0 },
+      coordinates: new Coordinates({ x: 0, y: 0 }),
+    } as DragAndDropData);
+  });
+  expect(container).not.toContainElement(getByTestId("drag-handle"));
+  act(() => {
+    mockController.discard();
+  });
+  expect(container).toContainElement(getByTestId("drag-handle"));
 });

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -17,6 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   DragAndDropData,
   DropTargetContext,
@@ -383,12 +384,15 @@ function ItemContainerComponent(
   }));
 
   const isActive = (!!transition && !transition.isBorrowed) || !!acquired;
+  const shouldUsePortal =
+    (transition?.operation === "insert" || transition?.operation === "reorder") &&
+    transition?.interactionType === "pointer";
   const childrenRef = useRef<ReactNode>(null);
   if (!inTransition || isActive) {
     childrenRef.current = children();
   }
 
-  return (
+  const content = (
     <div
       ref={itemRef}
       className={clsx(styles.root, ...itemTransitionClassNames)}
@@ -418,4 +422,6 @@ function ItemContainerComponent(
       </ItemContext.Provider>
     </div>
   );
+
+  return shouldUsePortal ? <div>{createPortal(content, document.body)}</div> : content;
 }

--- a/src/internal/item-container/styles.scss
+++ b/src/internal/item-container/styles.scss
@@ -17,11 +17,11 @@
   display: none;
 }
 .dragged {
-  z-index: 5000;
+  z-index: 2000;
   position: fixed;
 }
 .resized {
-  z-index: 5000;
+  z-index: 2000;
   position: absolute;
 }
 .borrowed {

--- a/src/internal/utils/use-auto-scroll.ts
+++ b/src/internal/utils/use-auto-scroll.ts
@@ -68,7 +68,7 @@ export function useAutoScroll() {
           document.activeElement === activeElementBeforeDelay &&
           getLastInteraction() === "keyboard"
         ) {
-          document.activeElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          document.activeElement.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
         }
       }, delay);
     },

--- a/src/test-utils/dom/board/index.ts
+++ b/src/test-utils/dom/board/index.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+import { ComponentWrapper, createWrapper } from "@cloudscape-design/test-utils-core/dom";
 import boardStyles from "../../../board/styles.selectors.js";
 import BoardItemWrapper from "../board-item";
 
@@ -8,6 +8,6 @@ export default class BoardWrapper extends ComponentWrapper {
   static rootSelector: string = boardStyles.root;
 
   findItemById(itemId: string): null | BoardItemWrapper {
-    return this.findComponent(`[data-item-id="${itemId}"]`, BoardItemWrapper);
+    return createWrapper().findComponent(`[data-item-id="${itemId}"]`, BoardItemWrapper);
   }
 }

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -27,8 +27,8 @@ test(
     async (page) => {
       await page.mouseDown(boardWrapper.findItemById("A").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
-        ["A", "B", "C", "D"],
-        ["A", "B", "C", "D"],
+        [" ", "B", "C", "D"],
+        [" ", "B", "C", "D"],
         ["E", "B", "G", "H"],
         ["E", "B", "G", "H"],
         [" ", " ", " ", " "],
@@ -38,10 +38,10 @@ test(
 
       await page.mouseDown(boardWrapper.findItemById("B").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
-        ["A", "B", "C", "D"],
-        ["A", "B", "C", "D"],
-        ["E", "B", "G", "H"],
-        ["E", "B", "G", "H"],
+        ["A", " ", "C", "D"],
+        ["A", " ", "C", "D"],
+        ["E", " ", "G", "H"],
+        ["E", " ", "G", "H"],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],


### PR DESCRIPTION
### Description

Self explanatory. Refactored to use portals for currently dragged item

Related links, issue #, if available: AWSUI-21442

### How has this been tested?

* PR build
* Added a unit test to check when portal is activated
* The exact overlap issues are hard to test automatically (requires flaky screenshot test)

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
