### PR TITLE
fix: Add sourceId to avoid palette and board actions interfere each other

### DIFF
--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -293,6 +293,7 @@ export function InternalBoard<D>({
                       maxHeight: gridContext.getHeight(itemMaxSize.height),
                     })}
                     onKeyMove={onItemMove}
+                    sourceId={"board"}
                   >
                     {item.id === acquiredItem?.id && acquiredItemElement
                       ? () => acquiredItemElement

--- a/src/board/placeholder.tsx
+++ b/src/board/placeholder.tsx
@@ -31,7 +31,7 @@ export default function Placeholder({ id, state, gridContext, columns }: Placeho
     },
   };
 
-  useDroppable({ itemId: id, context: dropTargetContext, getElement: () => ref.current! });
+  useDroppable({ itemId: id, context: dropTargetContext, getElement: () => ref.current!, sourceId: "board" });
 
   return <div ref={ref} className={clsx(styles.placeholder, styles[`placeholder--${state}`])} />;
 }

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -22,6 +22,7 @@ const defaultProps: ItemContainerProps = {
   inTransition: false,
   getItemSize: () => ({ width: 1, minWidth: 1, maxWidth: 1, height: 1, minHeight: 1, maxHeight: 1 }),
   children: () => <Item />,
+  sourceId: "board",
 };
 
 function Item() {
@@ -47,19 +48,19 @@ test("renders item container", () => {
 test("starts drag transition when drag handle is clicked and item belongs to grid", () => {
   const { getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
   getByTestId("drag-handle").click();
-  expect(mockDraggable.start).toBeCalledWith("reorder", "pointer", expect.any(Coordinates));
+  expect(mockDraggable.start).toBeCalledWith("reorder", "pointer", expect.any(Coordinates), "board");
 });
 
 test("starts insert transition when drag handle is clicked and item does not belong to grid", () => {
   const { getByTestId } = render(<ItemContainer {...defaultProps} />);
   getByTestId("drag-handle").click();
-  expect(mockDraggable.start).toBeCalledWith("insert", "pointer", expect.any(Coordinates));
+  expect(mockDraggable.start).toBeCalledWith("insert", "pointer", expect.any(Coordinates), "board");
 });
 
 test("starts resize transition when resize handle is clicked", () => {
   const { getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
   getByTestId("resize-handle").click();
-  expect(mockDraggable.start).toBeCalledWith("resize", "pointer", expect.any(Coordinates));
+  expect(mockDraggable.start).toBeCalledWith("resize", "pointer", expect.any(Coordinates), "board");
 });
 
 test("renders in portal when item in reorder state by a pointer", () => {

--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -109,6 +109,7 @@ export function InternalItemsPalette<D>({
                 const { width, height } = dropContext.scale(item);
                 return { width, minWidth: width, maxWidth: width, height, minHeight: height, maxHeight: height };
               }}
+              sourceId={"palette"}
             >
               {() =>
                 renderItem(item, {


### PR DESCRIPTION
### Description

It is reported that when dragging item from palette to board, the item in palette is not hidden. It is because [a submit() is called when item gets blurred](https://github.com/cloudscape-design/board-components/blob/main/src/internal/item-container/index.tsx#L298), before [borrowed state gets updated](https://github.com/cloudscape-design/board-components/blob/main/src/internal/item-container/index.tsx#L166). In our demo, submit is expected to be stoped because borrowed state is already updated. But it turns to be a racing condition, sometimes submit gets fired earlier than acquire. 

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
