### PR TITLE
fix: removedItem in onItemChange event detail is always null

### DIFF
--- a/src/board/__tests__/board.test.tsx
+++ b/src/board/__tests__/board.test.tsx
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { Button } from "@cloudscape-design/components";
 import { KeyCode } from "@cloudscape-design/test-utils-core/utils";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { vi } from "vitest";
@@ -52,7 +53,18 @@ const defaultProps: BoardProps<{ title: string }> = {
     { id: "1", data: { title: "Item 1" } },
     { id: "2", data: { title: "Item 2" } },
   ],
-  renderItem: (item) => <BoardItem i18nStrings={itemI18nStrings}>{item.data.title}</BoardItem>,
+  renderItem: (item, actions) => (
+    <BoardItem
+      i18nStrings={itemI18nStrings}
+      settings={
+        <Button data-testid="remove-button" onClick={() => actions.removeItem()}>
+          Remove
+        </Button>
+      }
+    >
+      {item.data.title}
+    </BoardItem>
+  ),
   onItemsChange: () => undefined,
   i18nStrings: i18nStrings,
   empty: "No items",
@@ -234,6 +246,24 @@ describe("Board", () => {
             { id: "1", data: { title: "Item 1" }, columnOffset: { 1: 0 }, columnSpan: 1, rowSpan: 4 },
             { id: "2", data: { title: "Item 2" }, columnOffset: { 1: 0 } },
           ],
+        },
+      })
+    );
+  });
+
+  test("triggers onItemsChange on remove", () => {
+    const onItemsChange = vi.fn();
+    render(<Board {...defaultProps} onItemsChange={onItemsChange} />);
+
+    const removeButton = createWrapper().findBoardItem()!.findSettings()!.find('[data-testid="remove-button"]')!;
+
+    removeButton.click();
+
+    expect(onItemsChange).toBeCalledWith(
+      expect.objectContaining({
+        detail: {
+          removedItem: expect.objectContaining({ id: "1" }),
+          items: [{ id: "2", data: { title: "Item 2" }, columnOffset: { 1: 0 } }],
         },
       })
     );

--- a/src/board/utils/events.ts
+++ b/src/board/utils/events.ts
@@ -20,7 +20,7 @@ export function createItemsChangeEvent<D>(
   return createCustomEvent({
     items: newItems,
     addedItem: newItems.find((it) => it.id === insertTarget),
-    removedItem: newItems.find((it) => it.id === removeTarget),
+    removedItem: items.find((it) => it.id === removeTarget),
     resizedItem: newItems.find((it) => it.id === resizeTarget),
     movedItem: !insertTarget ? newItems.find((it) => it.id === moveTarget) : undefined,
   });


### PR DESCRIPTION
### Description

fix that removedItem is always null in onItemChange event detail.

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
