### PR TITLE
chore: Don't render items in portals when reordering

### DIFF
--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -30,6 +30,18 @@ const createDefaultWidget = (id: string) => ({
   content: <DefaultContainer>Dummy content</DefaultContainer>,
 });
 
+const createDefaultWidgetWithInput = (id: string) => {
+  return {
+    title: `Widget ${id}`,
+    description: "Dummy description",
+    content: (
+      <DefaultContainer>
+        <input data-testid="input-field" />
+      </DefaultContainer>
+    ),
+  };
+};
+
 export const demoWidgets: ItemWidgets = {
   D: {
     definition: { defaultColumnSpan: 2, defaultRowSpan: 4, minRowSpan: 4 },
@@ -181,7 +193,7 @@ export const demoWidgets: ItemWidgets = {
 };
 
 for (let i = 2; i <= 10; i++) {
-  demoWidgets[i] = { data: createDefaultWidget(i.toString()) };
+  demoWidgets[i] = { data: i === 5 ? createDefaultWidgetWithInput(i.toString()) : createDefaultWidget(i.toString()) };
 }
 
 export const storedPositions = [

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -62,7 +62,7 @@ test("starts resize transition when resize handle is clicked", () => {
   expect(mockDraggable.start).toBeCalledWith("resize", "pointer", expect.any(Coordinates));
 });
 
-test("renders in portal when item in reorder state by a pointer", () => {
+test("does not renders in portal when item in reorder state by a pointer", () => {
   const { container, getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
   expect(container).toContainElement(getByTestId("drag-handle"));
   act(() => {
@@ -74,7 +74,7 @@ test("renders in portal when item in reorder state by a pointer", () => {
       coordinates: new Coordinates({ x: 0, y: 0 }),
     } as DragAndDropData);
   });
-  expect(container).not.toContainElement(getByTestId("drag-handle"));
+  expect(container).toContainElement(getByTestId("drag-handle"));
   act(() => {
     mockController.discard();
   });

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -388,9 +388,7 @@ function ItemContainerComponent(
   }));
 
   const isActive = (!!transition && !isHidden) || !!acquired;
-  const shouldUsePortal =
-    (transition?.operation === "insert" || transition?.operation === "reorder") &&
-    transition?.interactionType === "pointer";
+  const shouldUsePortal = transition?.operation === "insert" && transition?.interactionType === "pointer";
   const childrenRef = useRef<ReactNode>(null);
   if (!inTransition || isActive) {
     childrenRef.current = children(!!transition?.hasDropTarget);

--- a/test/functional/board-layout/item-actions.test.ts
+++ b/test/functional/board-layout/item-actions.test.ts
@@ -106,3 +106,25 @@ describe("items removal", () => {
     })
   );
 });
+
+describe("items reordering", () => {
+  test(
+    "input content is preserved after reordering",
+    setupTest("/index.html#/dnd/engine", DndPageObject, async (page) => {
+      const input = await boardWrapper.findItemById("5").find("[data-testid='input-field']").getElement();
+
+      expect(await page.getValue(input)).toBe("");
+
+      await page.setValue(input, "test content");
+
+      expect(await page.getValue(input)).toBe("test content");
+
+      await page.dragAndDropTo(
+        boardWrapper.findItemById("5").findDragHandle().toSelector(),
+        boardWrapper.findItemById("6").findDragHandle().toSelector()
+      );
+
+      expect(await page.getValue(input)).toBe("test content");
+    })
+  );
+});

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -27,8 +27,8 @@ test(
     async (page) => {
       await page.mouseDown(boardWrapper.findItemById("A").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
-        [" ", "B", "C", "D"],
-        [" ", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
         ["E", "B", "G", "H"],
         ["E", "B", "G", "H"],
         [" ", " ", " ", " "],
@@ -38,10 +38,10 @@ test(
 
       await page.mouseDown(boardWrapper.findItemById("B").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
-        ["A", " ", "C", "D"],
-        ["A", " ", "C", "D"],
-        ["E", " ", "G", "H"],
-        ["E", " ", "G", "H"],
+        ["A", "B", "C", "D"],
+        ["A", "B", "C", "D"],
+        ["E", "B", "G", "H"],
+        ["E", "B", "G", "H"],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],
         [" ", " ", " ", " "],


### PR DESCRIPTION
### Description

The previous fix for preventing z-index issues (https://github.com/cloudscape-design/board-components/pull/258) introduced an unexpected regression:
- when reordering a board item, this would re-mount, losing its internal state or re-firing API calls. This was due to it being rendered in a React Portal while being re-ordered (to avoid the aforementioned z-index issues).

After some investigation, I concluded the original z-index issues raised by customers where not happening while reordering the items, instead they were happening only when inserting them from the palette to the board.

With this fix, we no longer render the items in Portals while being reordered (but still keep this functionality when inserting them), which seems a fair compromise given that widgets on the items palette don't have an initial state (they're just placeholders).

Related issue: AWSUI-21921

### How has this been tested?

Existing tests + added a test to cover board items not losing internal state when reordered.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
