### PR TITLE
fix: Unmount nodes on cleanup in micro-frontend integration page

### DIFF
--- a/pages/micro-frontend/integration.page.tsx
+++ b/pages/micro-frontend/integration.page.tsx
@@ -21,14 +21,12 @@ interface MicroFrontendWrapperProps {
 
 function MicroFrontendWrapper({ content }: MicroFrontendWrapperProps) {
   const ref = useRef(null);
-  const mountedRef = useRef(false);
 
   useLayoutEffect(() => {
-    if (mountedRef.current) {
-      return;
-    }
-    mountedRef.current = true;
-    createRoot(ref.current!).render(content);
+    const root = createRoot(ref.current!);
+    root.render(content);
+
+    return () => root.unmount();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return <div ref={ref} />;


### PR DESCRIPTION
### Description

When "micro-frontends" and mounted but never un-mounted the proper cleanup does not happen. As result when using React portals those are rendered multiple times instead of one.

### How has this been tested?

Manual testing, see below.

Before:

https://github.com/cloudscape-design/board-components/assets/20790937/a0cf8d37-f802-4f2b-819b-d48eeb235c1d

After:

https://github.com/cloudscape-design/board-components/assets/20790937/13ab72d2-5b0b-4fe9-9fe2-abd59fcb7351

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
