### PR TITLE
chore: Try fix remove-item test flakiness

### DIFF
--- a/test/functional/board-layout/live-announcements.test.ts
+++ b/test/functional/board-layout/live-announcements.test.ts
@@ -151,8 +151,8 @@ test(
     await page.keys(["Enter"]);
     await page.keys(["Enter"]);
 
-    // Waiting for remove transition.
-    await page.pause(200);
+    // Waiting for remove transition plus an offset to prevent flakiness.
+    await page.pause(200 + 100);
 
     await expect(page.getLiveAnnouncements()).resolves.toEqual(["Removed item Widget A. Disturbed 1 items."]);
   })


### PR DESCRIPTION
### Description

The delay in the test suite for item removal announcements is exactly the same as the code delay to trigger the announcement. The proximity of the delays might be the cause of the observed dry-run flakiness of this test.

### How has this been tested?

Runned integ test suite several times in a row to ensure stability

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
