### PR TITLE
fix: Restore styled focus rings to drag and resize handles

### DIFF
--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -1,26 +1,5 @@
 @use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
-
-@mixin focus-highlight($gutter: 4px, $border-radius: cs.$border-radius-control-default-focus-ring) {
-  position: relative;
-  box-sizing: border-box;
-  outline: none;
-  & {
-    outline: 2px dotted transparent;
-    outline-offset: calc($gutter - 1px);
-  }
-  &::before {
-    content: " ";
-    display: block;
-    position: absolute;
-    box-sizing: border-box;
-    left: calc(-1 * #{$gutter});
-    top: calc(-1 * #{$gutter});
-    width: calc(100% + 2 * #{$gutter});
-    height: calc(100% + 2 * #{$gutter});
-    border-radius: $border-radius;
-    border: 2px solid cs.$color-border-item-focused;
-  }
-}
+@use "../internal/shared.scss" as shared;
 
 .root {
   display: contents;
@@ -31,7 +10,7 @@
   box-shadow: cs.$shadow-container-active;
 
   :global([data-awsui-focus-visible]) & {
-    @include focus-highlight(0px, cs.$border-radius-container);
+    @include shared.focus-highlight(0px, cs.$border-radius-container);
   }
 }
 

--- a/src/internal/drag-handle/styles.scss
+++ b/src/internal/drag-handle/styles.scss
@@ -1,9 +1,15 @@
+@use "../shared.scss" as shared;
+
 .handle {
   cursor: grab;
 }
 
 .handle:active {
   cursor: grabbing;
+}
+
+.handle:not(.active):focus-visible {
+  @include shared.focus-highlight();
 }
 
 .active {

--- a/src/internal/resize-handle/styles.scss
+++ b/src/internal/resize-handle/styles.scss
@@ -1,5 +1,11 @@
+@use "../shared.scss" as shared;
+
 .handle {
   cursor: nwse-resize;
+}
+
+.handle:not(.active):focus-visible {
+  @include shared.focus-highlight();
 }
 
 .active {

--- a/src/internal/shared.scss
+++ b/src/internal/shared.scss
@@ -1,0 +1,23 @@
+@use "../../node_modules/@cloudscape-design/design-tokens/index.scss" as cs;
+
+@mixin focus-highlight($gutter: 4px, $border-radius: cs.$border-radius-control-default-focus-ring) {
+  position: relative;
+  box-sizing: border-box;
+  outline: none;
+  & {
+    outline: 2px dotted transparent;
+    outline-offset: calc($gutter - 1px);
+  }
+  &::before {
+    content: " ";
+    display: block;
+    position: absolute;
+    box-sizing: border-box;
+    left: calc(-1 * #{$gutter});
+    top: calc(-1 * #{$gutter});
+    width: calc(100% + 2 * #{$gutter});
+    height: calc(100% + 2 * #{$gutter});
+    border-radius: $border-radius;
+    border: 2px solid cs.$color-border-item-focused;
+  }
+}

--- a/src/internal/shared.scss
+++ b/src/internal/shared.scss
@@ -3,11 +3,9 @@
 @mixin focus-highlight($gutter: 4px, $border-radius: cs.$border-radius-control-default-focus-ring) {
   position: relative;
   box-sizing: border-box;
-  outline: none;
-  & {
-    outline: 2px dotted transparent;
-    outline-offset: calc($gutter - 1px);
-  }
+  outline: 2px dotted transparent;
+  outline-offset: calc($gutter - 1px);
+
   &::before {
     content: " ";
     display: block;

--- a/test/visual/drag-states.test.ts
+++ b/test/visual/drag-states.test.ts
@@ -77,6 +77,22 @@ class DndPageObject extends ScreenshotPageObject {
 }
 
 test(
+  "renders correctly styled focus ring around the drag handle",
+  setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
+    await page.focus(boardItemHandle("A"));
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+  })
+);
+
+test(
+  "renders correctly styled focus ring around the resize handle",
+  setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
+    await page.focus(boardItemResizeHandle("A"));
+    expect(await page.fullPageScreenshot()).toMatchImageSnapshot();
+  })
+);
+
+test(
   "active item overlays other items",
   setupTest("/index.html#/dnd/engine-a2h-test", DndPageObject, async (page) => {
     await page.focus(boardItemHandle("A"));


### PR DESCRIPTION
### Description

A past commit moved focus rings to the container level when the container was being moved or resized via keyboard, but also took them out when the buttons themselves were focused, which is incorrect.

Related links, issue #, if available: AWSUI-23006

It looks like every time I re-run screenshot tests, there’s different flaky screenshots each time. Looking at past PRs, this commit might not be the one that introduces the flakiness, but it does add new tests that are expected to fail (because they didn't exist before).

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
