### PR TITLE
feat: replace @cloudscape-design/components with subpath imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,13 +58,17 @@
       [" Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.", " SPDX-License-Identifier: Apache-2.0"]
     ],
     "no-restricted-imports": [
-      "warn",
+      "error",
       {
         "paths": [
           {
             "name": "react",
             "importNames": ["default"],
             "message": "Prefer named imports."
+          },
+          {
+            "name": "@cloudscape-design/components",
+            "message": "Prefer subpath imports."
           }
         ]
       }

--- a/pages/conditional/conditional.page.tsx
+++ b/pages/conditional/conditional.page.tsx
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, Container, Header } from "@cloudscape-design/components";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
 import { useState } from "react";
 import { Board, BoardItem, BoardProps } from "../../lib/components";
 import { boardI18nStrings, boardItemI18nStrings } from "../shared/i18n";

--- a/pages/dnd/commons.tsx
+++ b/pages/dnd/commons.tsx
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Button, FormField, SpaceBetween } from "@cloudscape-design/components";
 import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import FormField from "@cloudscape-design/components/form-field";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
 
 export function Counter() {

--- a/pages/dnd/engine-query-test.page.tsx
+++ b/pages/dnd/engine-query-test.page.tsx
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-import { Button, Form, FormField, Header, SpaceBetween, Textarea } from "@cloudscape-design/components";
+import Button from "@cloudscape-design/components/button";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Textarea from "@cloudscape-design/components/textarea";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import PageLayout from "../app/page-layout";

--- a/pages/dnd/events-table.tsx
+++ b/pages/dnd/events-table.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Link, StatusIndicator, Table } from "@cloudscape-design/components";
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
 
 interface EventItem {
   id: string;

--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Link, SpaceBetween } from "@cloudscape-design/components";
+import Box from "@cloudscape-design/components/box";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { BoardProps, ItemsPaletteProps } from "../../lib/components";
 import { fromMatrix } from "../../lib/components/internal/debug-tools";
 import { BoardItemDefinition, BoardItemDefinitionBase } from "../../lib/components/internal/interfaces";

--- a/pages/dnd/update-layout-test.page.tsx
+++ b/pages/dnd/update-layout-test.page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Header } from "@cloudscape-design/components";
+import Header from "@cloudscape-design/components/header";
 import { useState } from "react";
 import { Board, BoardItem, BoardProps, ItemsPalette, ItemsPaletteProps } from "../../lib/components";
 import PageLayout from "../app/page-layout";

--- a/pages/grid/with-widget-containers-compact.page.tsx
+++ b/pages/grid/with-widget-containers-compact.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Header } from "@cloudscape-design/components";
+import Header from "@cloudscape-design/components/header";
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";

--- a/pages/grid/with-widget-containers.page.tsx
+++ b/pages/grid/with-widget-containers.page.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Header } from "@cloudscape-design/components";
+import Header from "@cloudscape-design/components/header";
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";

--- a/pages/micro-frontend/integration.page.tsx
+++ b/pages/micro-frontend/integration.page.tsx
@@ -1,7 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AppLayout, Box, Button, ContentLayout, Header, SplitPanel } from "@cloudscape-design/components";
+import AppLayout from "@cloudscape-design/components/app-layout";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SplitPanel from "@cloudscape-design/components/split-panel";
 import { ReactNode, useLayoutEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { Board, BoardItem, ItemsPalette } from "../../lib/components";

--- a/pages/widget-container/permutations.page.tsx
+++ b/pages/widget-container/permutations.page.tsx
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Box, Button, ButtonDropdown, SpaceBetween } from "@cloudscape-design/components";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ButtonDropdown from "@cloudscape-design/components/button-dropdown";
 import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/with-app-layout/app-layout.tsx
+++ b/pages/with-app-layout/app-layout.tsx
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { AppLayout, Box, Button, ContentLayout, Header, SpaceBetween, SplitPanel } from "@cloudscape-design/components";
+import AppLayout from "@cloudscape-design/components/app-layout";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import SplitPanel from "@cloudscape-design/components/split-panel";
 import { ReactNode, useState } from "react";
 import { appLayoutI18nStrings, clientI18nStrings, splitPanelI18nStrings } from "../shared/i18n";
 

--- a/pages/with-app-layout/delete-confirmation-modal.tsx
+++ b/pages/with-app-layout/delete-confirmation-modal.tsx
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Form, Modal, SpaceBetween } from "@cloudscape-design/components";
+import Button from "@cloudscape-design/components/button";
+import Form from "@cloudscape-design/components/form";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { clientI18nStrings } from "../shared/i18n";
 
 export function DeleteConfirmationModal({

--- a/pages/with-app-layout/widgets-board.tsx
+++ b/pages/with-app-layout/widgets-board.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Box, Header } from "@cloudscape-design/components";
+import Box from "@cloudscape-design/components/box";
 import ButtonDropdown from "@cloudscape-design/components/button-dropdown";
+import Header from "@cloudscape-design/components/header";
 import { useState } from "react";
 import { Board, BoardItem, BoardProps } from "../../lib/components";
 import LiveRegion from "../../lib/components/internal/live-region";

--- a/pages/with-app-layout/widgets-palette.tsx
+++ b/pages/with-app-layout/widgets-palette.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Header } from "@cloudscape-design/components";
+import Header from "@cloudscape-design/components/header";
 import { BoardItem, ItemsPalette, ItemsPaletteProps } from "../../lib/components";
 import LiveRegion from "../../lib/components/internal/live-region";
 import { boardItemI18nStrings, clientI18nStrings, itemsPaletteI18nStrings } from "../shared/i18n";

--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Container } from "@cloudscape-design/components";
+import Container from "@cloudscape-design/components/container";
 import { cleanup, render as libRender } from "@testing-library/react";
 import { ReactElement } from "react";
 import { afterEach, describe, expect, test } from "vitest";

--- a/src/board/__tests__/board.test.tsx
+++ b/src/board/__tests__/board.test.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Button } from "@cloudscape-design/components";
+import Button from "@cloudscape-design/components/button";
 import { KeyCode } from "@cloudscape-design/test-utils-core/utils";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { vi } from "vitest";

--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Icon } from "@cloudscape-design/components";
+import Icon from "@cloudscape-design/components/icon";
 import clsx from "clsx";
 import { ForwardedRef, KeyboardEvent, PointerEvent, forwardRef } from "react";
 

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Icon } from "@cloudscape-design/components";
+import Icon from "@cloudscape-design/components/icon";
 import clsx from "clsx";
 import { KeyboardEvent, PointerEvent } from "react";
 import Handle from "../handle";


### PR DESCRIPTION
### Description

Subpath imports should be preferred, because they allow for better bundle size optimizations

Related links, issue #, if available: n/a

### How has this been tested?

Updated eslint config to validate imports in the future

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
