### PR TITLE
chore: RTL support for keyboard commands and pointer events

### DIFF
--- a/pages/app/page.tsx
+++ b/pages/app/page.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { pagesMap } from "../pages";
 
@@ -12,7 +12,10 @@ export interface PageProps {
 export default function Page({ pageId }: PageProps) {
   const [searchParams] = useSearchParams();
   const direction = searchParams.get("direction") ?? "ltr";
-  document.documentElement.setAttribute("dir", direction);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("dir", direction);
+  }, [direction]);
 
   const Component = pagesMap[pageId];
 

--- a/pages/app/page.tsx
+++ b/pages/app/page.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import { Suspense } from "react";
+import { useSearchParams } from "react-router-dom";
 import { pagesMap } from "../pages";
 
 export interface PageProps {
@@ -8,6 +10,10 @@ export interface PageProps {
 }
 
 export default function Page({ pageId }: PageProps) {
+  const [searchParams] = useSearchParams();
+  const direction = searchParams.get("direction") ?? "ltr";
+  document.documentElement.setAttribute("dir", direction);
+
   const Component = pagesMap[pageId];
 
   return (

--- a/pages/dnd/engine-page-template.tsx
+++ b/pages/dnd/engine-page-template.tsx
@@ -41,6 +41,7 @@ export function EnginePageTemplate({
                   ariaLabel="Widget settings"
                   variant="icon"
                   onItemClick={() => actions.removeItem()}
+                  expandToViewport={true}
                 />
               }
               i18nStrings={boardItemI18nStrings}

--- a/pages/widget-container/permutations.page.tsx
+++ b/pages/widget-container/permutations.page.tsx
@@ -56,6 +56,7 @@ export default function WidgetContainerPermutations() {
                           { id: "two", text: "Two" },
                         ]}
                         variant="icon"
+                        expandToViewport={true}
                       />
                     }
                     i18nStrings={i18nStrings.boardItemI18nStrings}
@@ -91,6 +92,7 @@ export default function WidgetContainerPermutations() {
                           { id: "two", text: "Two" },
                         ]}
                         variant="icon"
+                        expandToViewport={true}
                       />
                     }
                     i18nStrings={i18nStrings.boardItemI18nStrings}
@@ -119,6 +121,7 @@ export default function WidgetContainerPermutations() {
                           { id: "two", text: "Two" },
                         ]}
                         variant="icon"
+                        expandToViewport={true}
                       />
                     }
                     i18nStrings={i18nStrings.boardItemI18nStrings}

--- a/pages/with-app-layout/widgets-board.tsx
+++ b/pages/with-app-layout/widgets-board.tsx
@@ -44,6 +44,7 @@ export function WidgetsBoard({ loading, widgets, onWidgetsChange }: WidgetsBoard
                 ariaLabel={clientI18nStrings.widgetsBoard.widgetSettings}
                 variant="icon"
                 onItemClick={() => setDeleteConfirmation(item.id)}
+                expandToViewport={true}
               />
             }
             i18nStrings={boardItemI18nStrings}

--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -50,6 +50,6 @@
 .resizer {
   position: absolute;
   // offset for inner paddings in the handle
-  bottom: calc(#{cs.$space-static-xs} - #{cs.$space-static-xxxs});
-  right: calc(#{cs.$space-static-xs} - #{cs.$space-static-xxxs});
+  inset-block-end: calc(#{cs.$space-static-xs} - #{cs.$space-static-xxxs});
+  inset-inline-end: calc(#{cs.$space-static-xs} - #{cs.$space-static-xxxs});
 }

--- a/src/board-item/styles.scss
+++ b/src/board-item/styles.scss
@@ -17,7 +17,8 @@
 .header {
   display: flex;
   justify-items: center;
-  padding: cs.$space-scaled-s calc(#{cs.$space-container-horizontal} - #{cs.$space-scaled-xs});
+  padding-block: cs.$space-scaled-s;
+  padding-inline: calc(#{cs.$space-container-horizontal} - #{cs.$space-scaled-xs});
 }
 
 .flexible {
@@ -25,21 +26,21 @@
 }
 
 .handle {
-  margin-top: calc(cs.$space-scaled-xxs + 1px);
+  margin-block-start: calc(cs.$space-scaled-xxs + 1px);
   .refresh > & {
-    margin-top: calc(cs.$space-static-xxxs + 1px);
+    margin-block-start: calc(cs.$space-static-xxxs + 1px);
   }
 }
 
 .header-content {
-  margin-left: cs.$space-scaled-xxs;
+  margin-inline-start: cs.$space-scaled-xxs;
 }
 
 .settings {
-  margin-top: calc(cs.$space-scaled-xxxs + 1px);
-  margin-left: cs.$space-static-xs;
+  margin-block-start: calc(cs.$space-scaled-xxxs + 1px);
+  margin-inline-start: cs.$space-static-xs;
   .refresh > & {
-    margin-top: 0px;
+    margin-block-start: 0px;
   }
 }
 

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -22,7 +22,7 @@ import {
   interpretItems,
 } from "../internal/utils/layout";
 import { Position } from "../internal/utils/position";
-import { getIsRtl } from "../internal/utils/screen";
+import { useIsRtl } from "../internal/utils/screen";
 import { useAutoScroll } from "../internal/utils/use-auto-scroll";
 import { useMergeRefs } from "../internal/utils/use-merge-refs";
 
@@ -48,7 +48,7 @@ export function InternalBoard<D>({
   const containerRef = useMergeRefs(containerAccessRef, containerQueryRef);
   const itemContainerRef = useRef<{ [id: ItemId]: ItemContainerRef }>({});
 
-  const isRtl = getIsRtl(containerAccessRef.current);
+  const isRtl = useIsRtl(containerAccessRef);
 
   useGlobalDragStateStyles();
 
@@ -115,8 +115,8 @@ export function InternalBoard<D>({
   function isElementOverBoard(rect: Rect) {
     const board = containerAccessRef.current!;
     const boardContains = (target: null | Element) => board === target || board.contains(target);
-    const left = !isRtl ? rect.left : document.documentElement.clientWidth - rect.left;
-    const right = !isRtl ? rect.right : document.documentElement.clientWidth - rect.right;
+    const left = !isRtl() ? rect.left : document.documentElement.clientWidth - rect.left;
+    const right = !isRtl() ? rect.right : document.documentElement.clientWidth - rect.right;
     const { top, bottom } = rect;
     return (
       boardContains(document.elementFromPoint(left, top)) ||

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -48,11 +48,13 @@ export function InternalBoard<D>({
   const containerRef = useMergeRefs(containerAccessRef, containerQueryRef);
   const itemContainerRef = useRef<{ [id: ItemId]: ItemContainerRef }>({});
 
+  const isRtl = getIsRtl(containerAccessRef.current);
+
   useGlobalDragStateStyles();
 
   const autoScrollHandlers = useAutoScroll();
 
-  const [transitionState, dispatch] = useTransition<D>();
+  const [transitionState, dispatch] = useTransition<D>({ isRtl });
   const transition = transitionState.transition;
   const removeTransition = transitionState.removeTransition;
   const transitionAnnouncement = transitionState.announcement;
@@ -113,7 +115,6 @@ export function InternalBoard<D>({
   function isElementOverBoard(rect: Rect) {
     const board = containerAccessRef.current!;
     const boardContains = (target: null | Element) => board === target || board.contains(target);
-    const isRtl = getIsRtl(document.documentElement);
     const left = !isRtl ? rect.left : document.documentElement.clientWidth - rect.left;
     const right = !isRtl ? rect.right : document.documentElement.clientWidth - rect.right;
     const { top, bottom } = rect;
@@ -233,7 +234,11 @@ export function InternalBoard<D>({
 
       <div ref={containerRef} className={clsx(styles.root, { [styles.empty]: rows === 0 })}>
         {rows > 0 ? (
-          <Grid columns={itemsLayout.columns} layout={[...placeholdersLayout.items, ...itemsLayout.items]}>
+          <Grid
+            isRtl={isRtl}
+            columns={itemsLayout.columns}
+            layout={[...placeholdersLayout.items, ...itemsLayout.items]}
+          >
             {(gridContext) => {
               const layoutShift = transition?.layoutShift ?? removeTransition?.layoutShift;
               const transforms = layoutShift ? createTransforms(itemsLayout, layoutShift.moves, gridContext) : {};
@@ -294,6 +299,7 @@ export function InternalBoard<D>({
                       maxHeight: gridContext.getHeight(itemMaxSize.height),
                     })}
                     onKeyMove={onItemMove}
+                    isRtl={isRtl}
                   >
                     {item.id === acquiredItem?.id && acquiredItemElement
                       ? () => acquiredItemElement

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -22,6 +22,7 @@ import {
   interpretItems,
 } from "../internal/utils/layout";
 import { Position } from "../internal/utils/position";
+import { getIsRtl } from "../internal/utils/screen";
 import { useAutoScroll } from "../internal/utils/use-auto-scroll";
 import { useMergeRefs } from "../internal/utils/use-merge-refs";
 
@@ -112,11 +113,15 @@ export function InternalBoard<D>({
   function isElementOverBoard(rect: Rect) {
     const board = containerAccessRef.current!;
     const boardContains = (target: null | Element) => board === target || board.contains(target);
+    const isRtl = getIsRtl(document.documentElement);
+    const left = !isRtl ? rect.left : document.documentElement.clientWidth - rect.left;
+    const right = !isRtl ? rect.right : document.documentElement.clientWidth - rect.right;
+    const { top, bottom } = rect;
     return (
-      boardContains(document.elementFromPoint(rect.left, rect.top)) ||
-      boardContains(document.elementFromPoint(rect.right, rect.top)) ||
-      boardContains(document.elementFromPoint(rect.right, rect.bottom)) ||
-      boardContains(document.elementFromPoint(rect.left, rect.bottom))
+      boardContains(document.elementFromPoint(left, top)) ||
+      boardContains(document.elementFromPoint(right, top)) ||
+      boardContains(document.elementFromPoint(right, bottom)) ||
+      boardContains(document.elementFromPoint(left, bottom))
     );
   }
 

--- a/src/board/styles.scss
+++ b/src/board/styles.scss
@@ -2,7 +2,7 @@
 
 .placeholder {
   border-radius: cs.$border-radius-container;
-  height: 100%;
+  block-size: 100%;
   &--active {
     background-color: cs.$color-board-placeholder-active;
   }
@@ -17,8 +17,10 @@
 
 .empty {
   box-sizing: border-box;
-  width: 100%;
-  padding: cs.$space-scaled-m cs.$space-scaled-l cs.$space-scaled-l;
+  inline-size: 100%;
+  padding-block-start: cs.$space-scaled-m;
+  padding-block-end: cs.$space-scaled-l;
+  padding-inline: cs.$space-scaled-l;
   color: cs.$color-text-empty;
   display: flex;
   justify-content: center;

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -67,7 +67,7 @@ interface AcquireItemAction {
   acquiredItemElement?: ReactNode;
 }
 
-export function useTransition<D>({ isRtl }: { isRtl: boolean }): [TransitionState<D>, Dispatch<Action<D>>] {
+export function useTransition<D>({ isRtl }: { isRtl: () => boolean }): [TransitionState<D>, Dispatch<Action<D>>] {
   return useReducer(createTransitionReducer<D>({ isRtl }), {
     transition: null,
     removeTransition: null,
@@ -79,7 +79,7 @@ export function selectTransitionRows<D>(state: TransitionState<D>) {
   return state.transition ? getLayoutRows(state.transition) : 0;
 }
 
-function createTransitionReducer<D>({ isRtl }: { isRtl: boolean }) {
+function createTransitionReducer<D>({ isRtl }: { isRtl: () => boolean }) {
   return function transitionReducer(state: TransitionState<D>, action: Action<D>): TransitionState<D> {
     switch (action.type) {
       case "init":
@@ -263,7 +263,7 @@ function updateTransitionWithPointerEvent<D>(
 function updateTransitionWithKeyboardEvent<D>(
   state: TransitionState<D>,
   { direction }: UpdateWithKeyboardAction,
-  { isRtl }: { isRtl: boolean },
+  { isRtl }: { isRtl: () => boolean },
 ): TransitionState<D> {
   const { transition } = state;
 
@@ -307,9 +307,9 @@ function updateTransitionWithKeyboardEvent<D>(
 
   switch (direction) {
     case "left":
-      return updateManualItemTransition(transition, !isRtl ? "left" : "right");
+      return updateManualItemTransition(transition, !isRtl() ? "left" : "right");
     case "right":
-      return updateManualItemTransition(transition, !isRtl ? "right" : "left");
+      return updateManualItemTransition(transition, !isRtl() ? "right" : "left");
     case "up":
       return updateManualItemTransition(transition, "up");
     case "down":

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -326,9 +326,7 @@ function acquireTransitionItem<D>(
 
   const layoutRect = getLogicalBoundingClientRect(layoutElement);
   const itemRect = transition.draggableRect;
-  const isRtl = document.documentElement.dir === "rtl";
-  // TODO: update
-  const coordinatesX = !isRtl ? itemRect.left - layoutRect.left : itemRect.left - layoutRect.left;
+  const coordinatesX = itemRect.left - layoutRect.left;
   const offset = new Coordinates({ x: coordinatesX, y: itemRect.top - layoutRect.top });
   const insertionDirection = getInsertionDirection(offset);
 

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -297,11 +297,13 @@ function updateTransitionWithKeyboardEvent<D>(
     }
   };
 
+  const isRtl = document.documentElement.dir === "rtl";
+
   switch (direction) {
     case "left":
-      return updateManualItemTransition(transition, "left");
+      return updateManualItemTransition(transition, !isRtl ? "left" : "right");
     case "right":
-      return updateManualItemTransition(transition, "right");
+      return updateManualItemTransition(transition, !isRtl ? "right" : "left");
     case "up":
       return updateManualItemTransition(transition, "up");
     case "down":

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -7,6 +7,7 @@ import { LayoutEngine } from "../internal/layout-engine/engine";
 import { Coordinates } from "../internal/utils/coordinates";
 import { getDefaultColumnSpan, getDefaultRowSpan, getMinColumnSpan, getMinRowSpan } from "../internal/utils/layout";
 import { Position } from "../internal/utils/position";
+import { getLogicalBoundingClientRect } from "../internal/utils/screen";
 import { BoardProps, RemoveTransition, Transition, TransitionAnnouncement } from "./interfaces";
 import { createOperationAnnouncement } from "./utils/announcements";
 import { getHoveredRect } from "./utils/get-hovered-rect";
@@ -323,9 +324,12 @@ function acquireTransitionItem<D>(
 
   const { columns } = transition.itemsLayout;
 
-  const layoutRect = layoutElement.getBoundingClientRect();
+  const layoutRect = getLogicalBoundingClientRect(layoutElement);
   const itemRect = transition.draggableRect;
-  const offset = new Coordinates({ x: itemRect.left - layoutRect.x, y: itemRect.top - layoutRect.y });
+  const isRtl = document.documentElement.dir === "rtl";
+  // TODO: update
+  const coordinatesX = !isRtl ? itemRect.left - layoutRect.left : itemRect.left - layoutRect.left;
+  const offset = new Coordinates({ x: coordinatesX, y: itemRect.top - layoutRect.top });
   const insertionDirection = getInsertionDirection(offset);
 
   // Update original insertion position if the item can't fit into the layout by width.

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -7,7 +7,7 @@ import { LayoutEngine } from "../internal/layout-engine/engine";
 import { Coordinates } from "../internal/utils/coordinates";
 import { getDefaultColumnSpan, getDefaultRowSpan, getMinColumnSpan, getMinRowSpan } from "../internal/utils/layout";
 import { Position } from "../internal/utils/position";
-import { getLogicalBoundingClientRect } from "../internal/utils/screen";
+import { getIsRtl, getLogicalBoundingClientRect } from "../internal/utils/screen";
 import { BoardProps, RemoveTransition, Transition, TransitionAnnouncement } from "./interfaces";
 import { createOperationAnnouncement } from "./utils/announcements";
 import { getHoveredRect } from "./utils/get-hovered-rect";
@@ -298,7 +298,7 @@ function updateTransitionWithKeyboardEvent<D>(
     }
   };
 
-  const isRtl = document.documentElement.dir === "rtl";
+  const isRtl = getIsRtl(document.documentElement);
 
   switch (direction) {
     case "left":
@@ -326,8 +326,8 @@ function acquireTransitionItem<D>(
 
   const layoutRect = getLogicalBoundingClientRect(layoutElement);
   const itemRect = transition.draggableRect;
-  const coordinatesX = itemRect.left - layoutRect.left;
-  const offset = new Coordinates({ x: coordinatesX, y: itemRect.top - layoutRect.top });
+  const coordinatesX = itemRect.left - layoutRect.insetInlineStart;
+  const offset = new Coordinates({ x: coordinatesX, y: itemRect.top - layoutRect.insetBlockStart });
   const insertionDirection = getInsertionDirection(offset);
 
   // Update original insertion position if the item can't fit into the layout by width.

--- a/src/internal/global-drag-state-styles/styles.scss
+++ b/src/internal/global-drag-state-styles/styles.scss
@@ -1,3 +1,5 @@
+@use "../shared.scss" as shared;
+
 .show-grab-cursor * {
   cursor: grabbing;
 }

--- a/src/internal/global-drag-state-styles/styles.scss
+++ b/src/internal/global-drag-state-styles/styles.scss
@@ -4,6 +4,10 @@
 
 .show-resize-cursor * {
   cursor: nwse-resize;
+
+  @include shared.with-direction('rtl') {
+    cursor: nesw-resize;
+  }
 }
 
 .disable-selection * {

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -5,7 +5,6 @@ import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 import { useDensityMode } from "@cloudscape-design/component-toolkit/internal";
 import clsx from "clsx";
 import { Children, useRef } from "react";
-import { getIsRtl } from "../../internal/utils/screen";
 import { useMergeRefs } from "../utils/use-merge-refs";
 import { zipTwoArrays } from "../utils/zip-arrays";
 
@@ -25,13 +24,12 @@ const ROWSPAN_HEIGHT = {
   compact: 76,
 };
 
-export default function Grid({ layout, children: render, columns }: GridProps) {
+export default function Grid({ layout, children: render, columns, isRtl }: GridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const [gridWidth, containerQueryRef] = useContainerQuery((entry) => entry.contentBoxWidth, []);
   const densityMode = useDensityMode(gridRef);
   const gridGap = GRID_GAP[densityMode];
   const rowspanHeight = ROWSPAN_HEIGHT[densityMode];
-  const isRtl = gridRef.current ? getIsRtl(gridRef.current) : false;
 
   // The below getters translate relative grid units into size/offset values in pixels.
   const getWidth = (colspan: number) => {

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -40,7 +40,7 @@ export default function Grid({ layout, children: render, columns, isRtl }: GridP
   const getHeight = (rowspan: number) => rowspan * rowspanHeight + (rowspan - 1) * gridGap;
   const getColOffset = (x: number) => {
     const offset = getWidth(x) + gridGap;
-    return !isRtl ? offset : -offset;
+    return !isRtl?.() ? offset : -offset;
   };
   const getRowOffset = (y: number) => getHeight(y) + gridGap;
 

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -38,7 +38,11 @@ export default function Grid({ layout, children: render, columns }: GridProps) {
     return colspan * cellWidth + (colspan - 1) * gridGap;
   };
   const getHeight = (rowspan: number) => rowspan * rowspanHeight + (rowspan - 1) * gridGap;
-  const getColOffset = (x: number) => getWidth(x) + gridGap;
+  const getColOffset = (x: number) => {
+    const offset = getWidth(x) + gridGap;
+    const isRtl = document.documentElement.dir === "rtl";
+    return !isRtl ? offset : -offset;
+  };
   const getRowOffset = (y: number) => getHeight(y) + gridGap;
 
   const gridContext = { getWidth, getHeight, getColOffset, getRowOffset };

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -5,6 +5,7 @@ import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 import { useDensityMode } from "@cloudscape-design/component-toolkit/internal";
 import clsx from "clsx";
 import { Children, useRef } from "react";
+import { getIsRtl } from "../../internal/utils/screen";
 import { useMergeRefs } from "../utils/use-merge-refs";
 import { zipTwoArrays } from "../utils/zip-arrays";
 
@@ -30,6 +31,7 @@ export default function Grid({ layout, children: render, columns }: GridProps) {
   const densityMode = useDensityMode(gridRef);
   const gridGap = GRID_GAP[densityMode];
   const rowspanHeight = ROWSPAN_HEIGHT[densityMode];
+  const isRtl = gridRef.current ? getIsRtl(gridRef.current) : false;
 
   // The below getters translate relative grid units into size/offset values in pixels.
   const getWidth = (colspan: number) => {
@@ -40,7 +42,6 @@ export default function Grid({ layout, children: render, columns }: GridProps) {
   const getHeight = (rowspan: number) => rowspan * rowspanHeight + (rowspan - 1) * gridGap;
   const getColOffset = (x: number) => {
     const offset = getWidth(x) + gridGap;
-    const isRtl = document.documentElement.dir === "rtl";
     return !isRtl ? offset : -offset;
   };
   const getRowOffset = (y: number) => getHeight(y) + gridGap;

--- a/src/internal/grid/interfaces.ts
+++ b/src/internal/grid/interfaces.ts
@@ -8,7 +8,7 @@ export interface GridProps {
   layout: GridLayoutItem[];
   columns: number;
   children?: (context: GridContext) => ReactNode;
-  isRtl?: boolean;
+  isRtl?: () => boolean;
 }
 
 export interface GridContext {

--- a/src/internal/grid/interfaces.ts
+++ b/src/internal/grid/interfaces.ts
@@ -8,6 +8,7 @@ export interface GridProps {
   layout: GridLayoutItem[];
   columns: number;
   children?: (context: GridContext) => ReactNode;
+  isRtl?: boolean;
 }
 
 export interface GridContext {

--- a/src/internal/handle/styles.scss
+++ b/src/internal/handle/styles.scss
@@ -4,7 +4,8 @@
   appearance: none;
   background: transparent;
   border: none;
-  padding: cs.$space-scaled-xxs;
+  padding-block: cs.$space-scaled-xxs;
+  padding-inline: cs.$space-scaled-xxs;
 
   color: cs.$color-text-interactive-default;
 

--- a/src/internal/item-container/__tests__/get-next-droppable.test.ts
+++ b/src/internal/item-container/__tests__/get-next-droppable.test.ts
@@ -7,7 +7,7 @@ import { getNextDroppable } from "../../../../lib/components/internal/item-conta
 
 function getMockElement({ left, right, top, bottom }: Rect) {
   return {
-    getBoundingClientRect: () => ({ left, right, top, bottom }),
+    getBoundingClientRect: () => ({ left, right, top, bottom, width: right - left, height: bottom - top }),
     ownerDocument: {
       defaultView: {
         pageXOffset: 0,

--- a/src/internal/item-container/__tests__/get-next-droppable.test.ts
+++ b/src/internal/item-container/__tests__/get-next-droppable.test.ts
@@ -19,19 +19,22 @@ function getMockElement({ left, right, top, bottom }: Rect) {
 
 test("returns null if there are no droppables", () => {
   const elementMock = getMockElement({ left: 0, right: 0, top: 0, bottom: 0 });
-  expect(getNextDroppable(elementMock, [], "left")).toBe(null);
+  expect(getNextDroppable({ draggableElement: elementMock, droppables: [], direction: "left", isRtl: false })).toBe(
+    null,
+  );
 });
 
 test("returns next droppable matching the direction", () => {
   const elementMock = getMockElement({ left: 6, right: 4, top: 0, bottom: 0 });
-  const next = getNextDroppable(
-    elementMock,
-    [
+  const next = getNextDroppable({
+    draggableElement: elementMock,
+    droppables: [
       ["1", { element: getMockElement({ left: 0, right: 10, top: 0, bottom: 0 }) } as Droppable],
       ["2", { element: getMockElement({ left: 5, right: 5, top: 0, bottom: 0 }) } as Droppable],
       ["3", { element: getMockElement({ left: 10, right: 0, top: 0, bottom: 0 }) } as Droppable],
     ],
-    "right",
-  );
+    direction: "right",
+    isRtl: false,
+  });
   expect(next).toBe("2");
 });

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -22,7 +22,7 @@ const defaultProps: ItemContainerProps = {
   inTransition: false,
   getItemSize: () => ({ width: 1, minWidth: 1, maxWidth: 1, height: 1, minHeight: 1, maxHeight: 1 }),
   children: () => <Item />,
-  isRtl: false,
+  isRtl: () => false,
 };
 
 function Item() {

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -22,6 +22,7 @@ const defaultProps: ItemContainerProps = {
   inTransition: false,
   getItemSize: () => ({ width: 1, minWidth: 1, maxWidth: 1, height: 1, minHeight: 1, maxHeight: 1 }),
   children: () => <Item />,
+  isRtl: false,
 };
 
 function Item() {

--- a/src/internal/item-container/get-next-droppable.ts
+++ b/src/internal/item-container/get-next-droppable.ts
@@ -10,13 +10,24 @@ import { getNormalizedElementRect } from "../utils/screen";
  * Finds closest droppable to provided draggable element and direction.
  * Returns null if there is no droppable in the given direction.
  */
-export function getNextDroppable(
-  draggableElement: HTMLElement,
-  droppables: readonly [ItemId, Droppable][],
-  direction: Direction,
-): null | ItemId {
+export function getNextDroppable({
+  draggableElement,
+  droppables,
+  direction,
+  isRtl,
+}: {
+  draggableElement: HTMLElement;
+  droppables: readonly [ItemId, Droppable][];
+  direction: Direction;
+  isRtl: boolean;
+}): null | ItemId {
   const draggableRect = getNormalizedElementRect(draggableElement);
   const sources = new Map(droppables.map(([id, d]) => [getNormalizedElementRect(d.element), id]));
-  const closest = getClosestNeighbor(draggableRect, [...sources.keys()], direction);
+  const closest = getClosestNeighbor({
+    target: draggableRect,
+    sources: [...sources.keys()],
+    direction,
+    isRtl,
+  });
   return sources.get(closest as DOMRect) ?? null;
 }

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -99,7 +99,7 @@ export interface ItemContainerProps {
   };
   onKeyMove?(direction: Direction): void;
   children: (hasDropTarget: boolean) => ReactNode;
-  isRtl: boolean;
+  isRtl: () => boolean;
 }
 
 export const ItemContainer = forwardRef(ItemContainerComponent);
@@ -177,7 +177,7 @@ function ItemContainerComponent(
   const transitionItemId = transition?.itemId ?? null;
   useEffect(() => {
     const onPointerMove = throttle((event: PointerEvent) => {
-      const coordinates = Coordinates.fromEvent(event, { isRtl });
+      const coordinates = Coordinates.fromEvent(event, { isRtl: isRtl() });
       draggableApi.updateTransition(
         new Coordinates({
           x: Math.max(coordinates.x, pointerBoundariesRef.current?.x ?? Number.NEGATIVE_INFINITY),
@@ -246,7 +246,12 @@ function ItemContainerComponent(
   function handleInsert(direction: Direction) {
     // Find the closest droppable (in the direction) to the item.
     const droppables = draggableApi.getDroppables();
-    const nextDroppable = getNextDroppable({ draggableElement: itemRef.current!, droppables, direction, isRtl });
+    const nextDroppable = getNextDroppable({
+      draggableElement: itemRef.current!,
+      droppables,
+      direction,
+      isRtl: isRtl(),
+    });
 
     if (!nextDroppable) {
       // TODO: add announcement
@@ -310,7 +315,7 @@ function ItemContainerComponent(
   function onDragHandlePointerDown(event: ReactPointerEvent) {
     // Calculate the offset between item's top-left corner and the pointer landing position.
     const rect = getLogicalBoundingClientRect(itemRef.current!);
-    const clientX = getLogicalClientX(event, isRtl);
+    const clientX = getLogicalClientX(event, isRtl());
     const clientY = event.clientY;
     pointerOffsetRef.current = new Coordinates({
       x: clientX - rect.insetInlineStart,
@@ -319,7 +324,7 @@ function ItemContainerComponent(
     originalSizeRef.current = { width: rect.inlineSize, height: rect.blockSize };
     pointerBoundariesRef.current = null;
 
-    draggableApi.start(!placed ? "insert" : "reorder", "pointer", Coordinates.fromEvent(event, { isRtl }));
+    draggableApi.start(!placed ? "insert" : "reorder", "pointer", Coordinates.fromEvent(event, { isRtl: isRtl() }));
   }
 
   function onDragHandleKeyDown(event: KeyboardEvent) {
@@ -329,7 +334,7 @@ function ItemContainerComponent(
   function onResizeHandlePointerDown(event: ReactPointerEvent) {
     // Calculate the offset between item's bottom-right corner and the pointer landing position.
     const rect = getLogicalBoundingClientRect(itemRef.current!);
-    const clientX = getLogicalClientX(event, isRtl);
+    const clientX = getLogicalClientX(event, isRtl());
     const clientY = event.clientY;
     pointerOffsetRef.current = new Coordinates({ x: clientX - rect.insetInlineEnd, y: clientY - rect.insetBlockEnd });
     originalSizeRef.current = { width: rect.inlineSize, height: rect.blockSize };
@@ -342,7 +347,7 @@ function ItemContainerComponent(
       y: clientY - rect.blockSize + minHeight,
     });
 
-    draggableApi.start("resize", "pointer", Coordinates.fromEvent(event, { isRtl }));
+    draggableApi.start("resize", "pointer", Coordinates.fromEvent(event, { isRtl: isRtl() }));
   }
 
   function onResizeHandleKeyDown(event: KeyboardEvent) {

--- a/src/internal/item-container/styles.scss
+++ b/src/internal/item-container/styles.scss
@@ -1,7 +1,7 @@
 .root {
   touch-action: none;
   position: relative;
-  height: 100%;
+  block-size: 100%;
 }
 
 .inTransition {

--- a/src/internal/resize-handle/styles.scss
+++ b/src/internal/resize-handle/styles.scss
@@ -2,6 +2,10 @@
 
 .handle {
   cursor: nwse-resize;
+
+  @include shared.with-direction('rtl') {
+    cursor: nesw-resize;
+  }
 }
 
 .handle:not(.active):focus-visible {

--- a/src/internal/screenreader-grid-navigation/styles.scss
+++ b/src/internal/screenreader-grid-navigation/styles.scss
@@ -5,7 +5,8 @@
 .screen-reader-navigation-visible {
   position: fixed;
   background: white;
-  padding: 8px;
+  padding-block: 8px;
+  padding-inline: 8px;
   border: 1px solid black;
   z-index: 10001;
 }

--- a/src/internal/screenreader-only/styles.scss
+++ b/src/internal/screenreader-only/styles.scss
@@ -5,6 +5,6 @@
 
 .root {
   position: absolute !important;
-  top: -9999px !important;
-  left: -9999px !important;
+  inset-block-start: -9999px !important;
+  inset-inline-start: -9999px !important;
 }

--- a/src/internal/shared.scss
+++ b/src/internal/shared.scss
@@ -19,3 +19,9 @@
     border: 2px solid cs.$color-border-item-focused;
   }
 }
+
+@mixin with-direction($direction) {
+  &:dir(#{$direction}) {
+    @content;
+  }
+}

--- a/src/internal/shared.scss
+++ b/src/internal/shared.scss
@@ -11,10 +11,10 @@
     display: block;
     position: absolute;
     box-sizing: border-box;
-    left: calc(-1 * #{$gutter});
-    top: calc(-1 * #{$gutter});
-    width: calc(100% + 2 * #{$gutter});
-    height: calc(100% + 2 * #{$gutter});
+    inset-inline-start: calc(-1 * #{$gutter});
+    inset-block-start: calc(-1 * #{$gutter});
+    inline-size: calc(100% + 2 * #{$gutter});
+    block-size: calc(100% + 2 * #{$gutter});
     border-radius: $border-radius;
     border: 2px solid cs.$color-border-item-focused;
   }

--- a/src/internal/utils/__tests__/rects.test.ts
+++ b/src/internal/utils/__tests__/rects.test.ts
@@ -95,16 +95,72 @@ describe("getGridPlacement", () => {
 
 describe("getClosestNeighbor", () => {
   test("returns null if can't find a neighbor in the given direction", () => {
-    expect(getClosestNeighbor({ left: -2, right: -1, top: 0, bottom: 1 }, grid, "left")).toBe(null);
-    expect(getClosestNeighbor({ left: 12, right: 13, top: 0, bottom: 1 }, grid, "right")).toBe(null);
-    expect(getClosestNeighbor({ left: 0, right: 1, top: -2, bottom: -1 }, grid, "up")).toBe(null);
-    expect(getClosestNeighbor({ left: 0, right: 1, top: 8, bottom: 9 }, grid, "down")).toBe(null);
+    expect(
+      getClosestNeighbor({
+        target: { left: -2, right: -1, top: 0, bottom: 1 },
+        sources: grid,
+        direction: "left",
+        isRtl: false,
+      }),
+    ).toBe(null);
+    expect(
+      getClosestNeighbor({
+        target: { left: 12, right: 13, top: 0, bottom: 1 },
+        sources: grid,
+        direction: "right",
+        isRtl: false,
+      }),
+    ).toBe(null);
+    expect(
+      getClosestNeighbor({
+        target: { left: 0, right: 1, top: -2, bottom: -1 },
+        sources: grid,
+        direction: "up",
+        isRtl: false,
+      }),
+    ).toBe(null);
+    expect(
+      getClosestNeighbor({
+        target: { left: 0, right: 1, top: 8, bottom: 9 },
+        sources: grid,
+        direction: "down",
+        isRtl: false,
+      }),
+    ).toBe(null);
   });
 
   test("returns closest grid cell in the given direction", () => {
-    expect(getClosestNeighbor({ left: -2, right: -1, top: 3, bottom: 4 }, grid, "right")).toBe(grid[3]);
-    expect(getClosestNeighbor({ left: 12, right: 13, top: 3, bottom: 4 }, grid, "left")).toBe(grid[5]);
-    expect(getClosestNeighbor({ left: 5, right: 6, top: -2, bottom: -1 }, grid, "down")).toBe(grid[1]);
-    expect(getClosestNeighbor({ left: 5, right: 6, top: 8, bottom: 9 }, grid, "up")).toBe(grid[4]);
+    expect(
+      getClosestNeighbor({
+        target: { left: -2, right: -1, top: 3, bottom: 4 },
+        sources: grid,
+        direction: "right",
+        isRtl: false,
+      }),
+    ).toBe(grid[3]);
+    expect(
+      getClosestNeighbor({
+        target: { left: 12, right: 13, top: 3, bottom: 4 },
+        sources: grid,
+        direction: "left",
+        isRtl: false,
+      }),
+    ).toBe(grid[5]);
+    expect(
+      getClosestNeighbor({
+        target: { left: 5, right: 6, top: -2, bottom: -1 },
+        sources: grid,
+        direction: "down",
+        isRtl: false,
+      }),
+    ).toBe(grid[1]);
+    expect(
+      getClosestNeighbor({
+        target: { left: 5, right: 6, top: 8, bottom: 9 },
+        sources: grid,
+        direction: "up",
+        isRtl: false,
+      }),
+    ).toBe(grid[4]);
   });
 });

--- a/src/internal/utils/coordinates.ts
+++ b/src/internal/utils/coordinates.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PointerEvent as ReactPointerEvent } from "react";
-import { getLogicalClientX } from "./screen";
+import { getIsRtl, getLogicalClientX } from "./screen";
 
 export class Coordinates {
   readonly __type = "Coordinates";
@@ -12,7 +12,8 @@ export class Coordinates {
   readonly scrollY = window.scrollY;
 
   static fromEvent(event: PointerEvent | ReactPointerEvent<unknown>): Coordinates {
-    const clientX = getLogicalClientX(event);
+    const isRtl = getIsRtl(document.documentElement);
+    const clientX = getLogicalClientX(event, isRtl);
     const clientY = event.clientY;
     return new Coordinates({ x: clientX, y: clientY });
   }

--- a/src/internal/utils/coordinates.ts
+++ b/src/internal/utils/coordinates.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PointerEvent as ReactPointerEvent } from "react";
-import { getIsRtl, getLogicalClientX } from "./screen";
+import { getLogicalClientX } from "./screen";
 
 export class Coordinates {
   readonly __type = "Coordinates";
@@ -11,8 +11,7 @@ export class Coordinates {
   readonly scrollX = window.scrollX;
   readonly scrollY = window.scrollY;
 
-  static fromEvent(event: PointerEvent | ReactPointerEvent<unknown>): Coordinates {
-    const isRtl = getIsRtl(document.documentElement);
+  static fromEvent(event: PointerEvent | ReactPointerEvent<unknown>, { isRtl }: { isRtl: boolean }): Coordinates {
     const clientX = getLogicalClientX(event, isRtl);
     const clientY = event.clientY;
     return new Coordinates({ x: clientX, y: clientY });

--- a/src/internal/utils/coordinates.ts
+++ b/src/internal/utils/coordinates.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PointerEvent as ReactPointerEvent } from "react";
+import { getLogicalClientX } from "./screen";
 
 export class Coordinates {
   readonly __type = "Coordinates";
@@ -11,7 +12,9 @@ export class Coordinates {
   readonly scrollY = window.scrollY;
 
   static fromEvent(event: PointerEvent | ReactPointerEvent<unknown>): Coordinates {
-    return new Coordinates({ x: event.clientX, y: event.clientY });
+    const clientX = getLogicalClientX(event);
+    const clientY = event.clientY;
+    return new Coordinates({ x: clientX, y: clientY });
   }
 
   static cursorOffset(current: Coordinates, start: Coordinates): Coordinates {

--- a/src/internal/utils/rects.ts
+++ b/src/internal/utils/rects.ts
@@ -72,6 +72,13 @@ export function getClosestNeighbor(target: Rect, sources: readonly Rect[], direc
   const verticalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.top - target.top) - Math.abs(r2.top - target.top);
   const horizontalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.left - target.left) - Math.abs(r2.left - target.left);
 
+  const isRtl = document.documentElement.dir === "rtl";
+  if (isRtl && direction === "left") {
+    direction = "right";
+  } else if (isRtl && direction === "right") {
+    direction = "left";
+  }
+
   switch (direction) {
     case "left":
       return getFirst(

--- a/src/internal/utils/rects.ts
+++ b/src/internal/utils/rects.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Direction, Rect } from "../interfaces";
+import { getIsRtl } from "./screen";
 
 export function isInside(rect: Rect, bounds: Rect) {
   return (
@@ -68,11 +69,11 @@ export function getGridPlacement(target: Rect, grid: readonly Rect[]): Rect {
 }
 
 export function getClosestNeighbor(target: Rect, sources: readonly Rect[], direction: Direction): null | Rect {
+  const isRtl = getIsRtl(document.documentElement);
   const getFirst = (rects: Rect[]) => rects[0] ?? null;
   const verticalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.top - target.top) - Math.abs(r2.top - target.top);
   const horizontalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.left - target.left) - Math.abs(r2.left - target.left);
 
-  const isRtl = document.documentElement.dir === "rtl";
   if (isRtl && direction === "left") {
     direction = "right";
   } else if (isRtl && direction === "right") {

--- a/src/internal/utils/rects.ts
+++ b/src/internal/utils/rects.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Direction, Rect } from "../interfaces";
-import { getIsRtl } from "./screen";
 
 export function isInside(rect: Rect, bounds: Rect) {
   return (
@@ -68,8 +67,17 @@ export function getGridPlacement(target: Rect, grid: readonly Rect[]): Rect {
   return placement;
 }
 
-export function getClosestNeighbor(target: Rect, sources: readonly Rect[], direction: Direction): null | Rect {
-  const isRtl = getIsRtl(document.documentElement);
+export function getClosestNeighbor({
+  target,
+  sources,
+  direction,
+  isRtl,
+}: {
+  target: Rect;
+  sources: readonly Rect[];
+  direction: Direction;
+  isRtl: boolean;
+}): null | Rect {
   const getFirst = (rects: Rect[]) => rects[0] ?? null;
   const verticalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.top - target.top) - Math.abs(r2.top - target.top);
   const horizontalDiff = (r1: Rect, r2: Rect) => Math.abs(r1.left - target.left) - Math.abs(r2.left - target.left);

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -24,14 +24,17 @@ export function getNormalizedElementRect(element: HTMLElement): {
   };
 }
 
-export function getIsRtl(element: null | Element | SVGElement) {
-  if (!element) {
+export function useIsRtl(elementRef: React.RefObject<Element>) {
+  const getIsRtl = (): boolean => {
+    if (!elementRef.current) {
+      return false;
+    }
+    if (elementRef.current instanceof Element) {
+      return getComputedStyle(elementRef.current).direction === "rtl";
+    }
     return false;
-  }
-  if (element instanceof Element) {
-    return getComputedStyle(element).direction === "rtl";
-  }
-  return false;
+  };
+  return getIsRtl;
 }
 
 /**
@@ -56,9 +59,10 @@ export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) 
   const inlineSize = boundingClientRect.width;
   const insetBlockStart = boundingClientRect.top;
   const insetBlockEnd = boundingClientRect.bottom;
-  const insetInlineStart = getIsRtl(element)
-    ? document.documentElement.clientWidth - boundingClientRect.right
-    : boundingClientRect.left;
+  const insetInlineStart =
+    element instanceof Element && getComputedStyle(element).direction === "rtl"
+      ? document.documentElement.clientWidth - boundingClientRect.right
+      : boundingClientRect.left;
   const insetInlineEnd = insetInlineStart + inlineSize;
 
   return {

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -1,18 +1,78 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export function getNormalizedElementRect(element: HTMLElement): DOMRect {
-  const { x, y, left, right, top, bottom, width, height } = element.getBoundingClientRect();
+import { PointerEvent as ReactPointerEvent } from "react";
+
+export function getNormalizedElementRect(element: HTMLElement): {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+} {
+  const { left, right, top, bottom, width, height } = getLogicalBoundingClientRect(element);
   const xOffset = element.ownerDocument.defaultView!.pageXOffset - window.scrollX;
   const yOffset = element.ownerDocument.defaultView!.pageYOffset - window.scrollY;
   return {
-    x: x + xOffset,
     left: left + xOffset,
     right: right + xOffset,
-    y: y + yOffset,
     top: top + yOffset,
     bottom: bottom + yOffset,
     width: width,
     height: height,
-  } as DOMRect;
+  };
+}
+
+// The below code is copied from components/src/internal/direction.ts
+
+export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) {
+  const boundingClientRect = element.getBoundingClientRect();
+
+  const blockSize = boundingClientRect.height;
+  const inlineSize = boundingClientRect.width;
+  const insetBlockStart = boundingClientRect.top;
+  const insetBlockEnd = boundingClientRect.bottom;
+  const insetInlineStart = getIsRtl(element)
+    ? document.documentElement.clientWidth - boundingClientRect.right
+    : boundingClientRect.left;
+  const insetInlineEnd = insetInlineStart + inlineSize;
+
+  return {
+    height: blockSize,
+    width: inlineSize,
+    top: insetBlockStart,
+    bottom: insetBlockEnd,
+    left: insetInlineStart,
+    right: insetInlineEnd,
+  };
+}
+
+export function getIsRtl(element: HTMLElement | SVGElement) {
+  return getComputedStyle(element).direction === "rtl";
+}
+
+export function getOffsetInlineStart(element: HTMLElement) {
+  const offsetParentWidth = element.offsetParent?.clientWidth ?? 0;
+  return getIsRtl(element) ? offsetParentWidth - element.offsetWidth - element.offsetLeft : element.offsetLeft;
+}
+
+/**
+ * The scrollLeft value will be a negative number if the direction is RTL and
+ * needs to be converted to a positive value for direction independent scroll
+ * computations. Additionally, the scrollLeft value can be a decimal value on
+ * systems using display scaling requiring the floor and ceiling calls.
+ */
+export function getScrollInlineStart(element: HTMLElement) {
+  return getIsRtl(element) ? Math.floor(element.scrollLeft) * -1 : Math.ceil(element.scrollLeft);
+}
+
+/**
+ * The clientX position needs to be converted so it is relative to the right of
+ * the document in order for computations to yield the same result in both
+ * element directions.
+ */
+export function getLogicalClientX(event: PointerEvent | ReactPointerEvent<unknown>) {
+  const isRtl = document.documentElement.dir === "rtl";
+  return isRtl ? document.documentElement.clientWidth - event.clientX : event.clientX;
 }

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -24,7 +24,10 @@ export function getNormalizedElementRect(element: HTMLElement): {
   };
 }
 
-export function getIsRtl(element: HTMLElement | SVGElement) {
+export function getIsRtl(element: null | HTMLElement | SVGElement) {
+  if (!element || !(element instanceof HTMLElement) || !(element instanceof SVGElement)) {
+    return false;
+  }
   return getComputedStyle(element).direction === "rtl";
 }
 
@@ -33,8 +36,8 @@ export function getIsRtl(element: HTMLElement | SVGElement) {
  * the document in order for computations to yield the same result in both
  * element directions.
  */
-export function getLogicalClientX(event: PointerEvent | ReactPointerEvent<unknown>, IsRtl: boolean) {
-  return IsRtl ? document.documentElement.clientWidth - event.clientX : event.clientX;
+export function getLogicalClientX(event: PointerEvent | ReactPointerEvent<unknown>, isRtl: boolean) {
+  return isRtl ? document.documentElement.clientWidth - event.clientX : event.clientX;
 }
 
 /**

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -25,15 +25,10 @@ export function getNormalizedElementRect(element: HTMLElement): {
 }
 
 export function useIsRtl(elementRef: React.RefObject<Element>) {
-  const getIsRtl = (): boolean => {
-    if (!elementRef.current) {
-      return false;
-    }
-    if (elementRef.current instanceof Element) {
-      return getComputedStyle(elementRef.current).direction === "rtl";
-    }
-    return false;
-  };
+  const getIsRtl = (): boolean =>
+    elementRef.current && elementRef.current instanceof Element
+      ? getComputedStyle(elementRef.current).direction === "rtl"
+      : false;
   return getIsRtl;
 }
 

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -24,11 +24,14 @@ export function getNormalizedElementRect(element: HTMLElement): {
   };
 }
 
-export function getIsRtl(element: null | HTMLElement | SVGElement) {
-  if (!element || !(element instanceof HTMLElement) || !(element instanceof SVGElement)) {
+export function getIsRtl(element: null | Element | SVGElement) {
+  if (!element) {
     return false;
   }
-  return getComputedStyle(element).direction === "rtl";
+  if (element instanceof Element) {
+    return getComputedStyle(element).direction === "rtl";
+  }
+  return false;
 }
 
 /**

--- a/src/internal/utils/screen.ts
+++ b/src/internal/utils/screen.ts
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 import { PointerEvent as ReactPointerEvent } from "react";
 
 export function getNormalizedElementRect(element: HTMLElement): {
@@ -11,21 +10,39 @@ export function getNormalizedElementRect(element: HTMLElement): {
   width: number;
   height: number;
 } {
-  const { left, right, top, bottom, width, height } = getLogicalBoundingClientRect(element);
+  const { insetInlineStart, insetInlineEnd, insetBlockStart, insetBlockEnd, inlineSize, blockSize } =
+    getLogicalBoundingClientRect(element);
   const xOffset = element.ownerDocument.defaultView!.pageXOffset - window.scrollX;
   const yOffset = element.ownerDocument.defaultView!.pageYOffset - window.scrollY;
   return {
-    left: left + xOffset,
-    right: right + xOffset,
-    top: top + yOffset,
-    bottom: bottom + yOffset,
-    width: width,
-    height: height,
+    left: insetInlineStart + xOffset,
+    right: insetInlineEnd + xOffset,
+    top: insetBlockStart + yOffset,
+    bottom: insetBlockEnd + yOffset,
+    width: inlineSize,
+    height: blockSize,
   };
 }
 
-// The below code is copied from components/src/internal/direction.ts
+export function getIsRtl(element: HTMLElement | SVGElement) {
+  return getComputedStyle(element).direction === "rtl";
+}
 
+/**
+ * The clientX position needs to be converted so it is relative to the right of
+ * the document in order for computations to yield the same result in both
+ * element directions.
+ */
+export function getLogicalClientX(event: PointerEvent | ReactPointerEvent<unknown>, IsRtl: boolean) {
+  return IsRtl ? document.documentElement.clientWidth - event.clientX : event.clientX;
+}
+
+/**
+ * The getBoundingClientRect() function returns values relative to the top left
+ * corner of the document regardless of document direction. The left/right position
+ * will be transformed to insetInlineStart based on element direction in order to
+ * support direction agnostic position computation.
+ */
 export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) {
   const boundingClientRect = element.getBoundingClientRect();
 
@@ -39,40 +56,11 @@ export function getLogicalBoundingClientRect(element: HTMLElement | SVGElement) 
   const insetInlineEnd = insetInlineStart + inlineSize;
 
   return {
-    height: blockSize,
-    width: inlineSize,
-    top: insetBlockStart,
-    bottom: insetBlockEnd,
-    left: insetInlineStart,
-    right: insetInlineEnd,
+    blockSize,
+    inlineSize,
+    insetBlockStart,
+    insetBlockEnd,
+    insetInlineStart,
+    insetInlineEnd,
   };
-}
-
-export function getIsRtl(element: HTMLElement | SVGElement) {
-  return getComputedStyle(element).direction === "rtl";
-}
-
-export function getOffsetInlineStart(element: HTMLElement) {
-  const offsetParentWidth = element.offsetParent?.clientWidth ?? 0;
-  return getIsRtl(element) ? offsetParentWidth - element.offsetWidth - element.offsetLeft : element.offsetLeft;
-}
-
-/**
- * The scrollLeft value will be a negative number if the direction is RTL and
- * needs to be converted to a positive value for direction independent scroll
- * computations. Additionally, the scrollLeft value can be a decimal value on
- * systems using display scaling requiring the floor and ceiling calls.
- */
-export function getScrollInlineStart(element: HTMLElement) {
-  return getIsRtl(element) ? Math.floor(element.scrollLeft) * -1 : Math.ceil(element.scrollLeft);
-}
-
-/**
- * The clientX position needs to be converted so it is relative to the right of
- * the document in order for computations to yield the same result in both
- * element directions.
- */
-export function getLogicalClientX(event: PointerEvent | ReactPointerEvent<unknown>) {
-  const isRtl = document.documentElement.dir === "rtl";
-  return isRtl ? document.documentElement.clientWidth - event.clientX : event.clientX;
 }

--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -9,6 +9,7 @@ import { ItemId } from "../internal/interfaces";
 import { ItemContainer, ItemContainerRef } from "../internal/item-container";
 import LiveRegion from "../internal/live-region";
 import { ScreenReaderGridNavigation } from "../internal/screenreader-grid-navigation";
+import { getIsRtl } from "../internal/utils/screen";
 import { ItemsPaletteProps } from "./interfaces";
 import styles from "./styles.css.js";
 
@@ -23,6 +24,8 @@ export function InternalItemsPalette<D>({
   const itemContainerRef = useRef<{ [id: ItemId]: ItemContainerRef }>({});
   const [dropState, setDropState] = useState<{ id: string }>();
   const [announcement, setAnnouncement] = useState("");
+
+  const isRtl = getIsRtl(paletteRef.current);
 
   function focusItem(itemId: ItemId) {
     itemContainerRef.current[itemId].focusDragHandle();
@@ -109,6 +112,7 @@ export function InternalItemsPalette<D>({
                 const { width, height } = dropContext.scale(item);
                 return { width, minWidth: width, maxWidth: width, height, minHeight: height, maxHeight: height };
               }}
+              isRtl={isRtl}
             >
               {(hasDropTarget) => renderItem(item, { showPreview: hasDropTarget })}
             </ItemContainer>

--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -9,7 +9,7 @@ import { ItemId } from "../internal/interfaces";
 import { ItemContainer, ItemContainerRef } from "../internal/item-container";
 import LiveRegion from "../internal/live-region";
 import { ScreenReaderGridNavigation } from "../internal/screenreader-grid-navigation";
-import { getIsRtl } from "../internal/utils/screen";
+import { useIsRtl } from "../internal/utils/screen";
 import { ItemsPaletteProps } from "./interfaces";
 import styles from "./styles.css.js";
 
@@ -25,7 +25,7 @@ export function InternalItemsPalette<D>({
   const [dropState, setDropState] = useState<{ id: string }>();
   const [announcement, setAnnouncement] = useState("");
 
-  const isRtl = getIsRtl(paletteRef.current);
+  const isRtl = useIsRtl(paletteRef);
 
   function focusItem(itemId: ItemId) {
     itemContainerRef.current[itemId].focusDragHandle();


### PR DESCRIPTION
### Description

Support for RTL

Observations:
* Settings button dropdown opens to the left when direction="rtl";
* Pressing arrow left when the palette is open causes screen to grow;
* Need to invert the resize icon and cursor.

https://github.com/cloudscape-design/board-components/assets/20790937/b9f645b2-bcf3-4caa-9b49-339f88b8375a


### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
