### PR TITLE
chore: Import sort plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
       "jsx": true
     }
   },
-  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import"],
+  "plugins": ["unicorn", "react-hooks", "no-unsanitized", "header", "import", "simple-import-sort"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
@@ -73,14 +73,13 @@
         ]
       }
     ],
-    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
-    "import/order": ["error", { "alphabetize": { "order": "asc" } }],
     "import/no-useless-path-segments": [
       "warn",
       {
         "noUselessIndex": true
       }
-    ]
+    ],
+    "simple-import-sort/imports": "warn"
   },
   "settings": {
     "react": {
@@ -101,6 +100,30 @@
       },
       "env": {
         "jest": true
+      }
+    },
+    {
+      "files": ["src/**", "pages/**", "test/**", "scripts/**"],
+      "rules": {
+        "simple-import-sort/imports": [
+          "warn",
+          {
+            "groups": [
+              // External packages come first.
+              ["^react", "^\\w", "^@testing", "^@vite", "^@dnd"],
+              // Cloudscape packages.
+              ["^@cloudscape"],
+              // Things that start with a letter (or digit or underscore), or `~` followed by a letter.
+              ["^~?\\w"],
+              // Anything not matched in another group.
+              ["^"],
+              // Styles come last.
+              [
+                "^.+\\.?(css)$","^.+\\.?(css.js)$", "^.+\\.?(scss)$", "^.+\\.?(selectors.js)$"
+              ]
+            ]
+          }
+        ]
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unicorn": "^45.0.2",
         "execa": "^6.1.0",
         "globby": "^13.1.3",
@@ -1787,6 +1788,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2962,6 +2978,27 @@
         "win32"
       ]
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3951,9 +3988,9 @@
       }
     },
     "node_modules/@types/pngjs": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.1.tgz",
-      "integrity": "sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4817,9 +4854,9 @@
       "dev": true
     },
     "node_modules/ace-builds": {
-      "version": "1.32.7",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.7.tgz",
-      "integrity": "sha512-ziv35kaYELFw4suWlotz/Xsl1/1LhWAbwFoD3zIgCgP9gXGECEsAM4GhiB0T0xZdmQjyv6hmAzO280g0+n4vGw==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.2.tgz",
+      "integrity": "sha512-06d00u4jDZx+ieI0jLlgy/uefx8kcgz7lhI0mCIFEu8NVWirH00U5IEP7tePHy4sjPsRcJUH4VbJZacoit2Hng==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -5180,6 +5217,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -7211,6 +7259,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "45.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
@@ -7805,6 +7862,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -11367,6 +11444,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12361,9 +12451,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14274,9 +14364,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -15669,6 +15759,25 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {
@@ -17502,6 +17611,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -18364,6 +18488,27 @@
       "dev": true,
       "optional": true
     },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -19185,9 +19330,9 @@
       }
     },
     "@types/pngjs": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.1.tgz",
-      "integrity": "sha512-J39njbdW1U/6YyVXvC9+1iflZghP8jgRf2ndYghdJb5xL49LYDB+1EuAxfbuJ2IBbWIL3AjHPQhgaTxT3YaYeg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -19828,9 +19973,9 @@
       "dev": true
     },
     "ace-builds": {
-      "version": "1.32.7",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.32.7.tgz",
-      "integrity": "sha512-ziv35kaYELFw4suWlotz/Xsl1/1LhWAbwFoD3zIgCgP9gXGECEsAM4GhiB0T0xZdmQjyv6hmAzO280g0+n4vGw==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.2.tgz",
+      "integrity": "sha512-06d00u4jDZx+ieI0jLlgy/uefx8kcgz7lhI0mCIFEu8NVWirH00U5IEP7tePHy4sjPsRcJUH4VbJZacoit2Hng==",
       "dev": true
     },
     "acorn": {
@@ -20097,6 +20242,17 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-jest": {
       "version": "29.3.1",
@@ -21735,6 +21891,13 @@
       "dev": true,
       "requires": {}
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-plugin-unicorn": {
       "version": "45.0.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz",
@@ -22069,6 +22232,12 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
     "for-each": {
@@ -24705,6 +24874,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25489,9 +25671,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {
@@ -26897,9 +27079,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -27905,6 +28087,19 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^45.0.2",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "execa": "^6.1.0",
     "globby": "^13.1.3",
     "husky": "^8.0.3",

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { HashRouter, Link, Route, Routes, useLocation } from "react-router-dom";
+
 import { pages } from "../pages";
 import Page from "./page";
 

--- a/pages/app/page.tsx
+++ b/pages/app/page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Suspense } from "react";
+
 import { pagesMap } from "../pages";
 
 export interface PageProps {

--- a/pages/app/test-bed.tsx
+++ b/pages/app/test-bed.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from "react";
+
 import classnames from "./test-bed.module.css";
 
 export const TestBed = ({ children }: { children: ReactNode }) => (

--- a/pages/canvas/layouts.page.tsx
+++ b/pages/canvas/layouts.page.tsx
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode } from "react";
+
 import { Board, BoardProps } from "../../lib/components";
 import { TestBed } from "../app/test-bed";
 import { ScreenshotArea } from "../screenshot-area";
 import { boardI18nStrings } from "../shared/i18n";
+
 import classnames from "./layouts.module.css";
 
 const singleItem: BoardProps.Item<any>[] = [

--- a/pages/conditional/conditional.page.tsx
+++ b/pages/conditional/conditional.page.tsx
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import { useState } from "react";
+
 import { Board, BoardItem, BoardProps } from "../../lib/components";
 import { boardI18nStrings, boardItemI18nStrings } from "../shared/i18n";
 import { ItemData } from "../shared/interfaces";

--- a/pages/dnd/commons.tsx
+++ b/pages/dnd/commons.tsx
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import FormField from "@cloudscape-design/components/form-field";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useState } from "react";
 
 export function Counter() {
   const [count, setCount] = useState(0);

--- a/pages/dnd/containers.tsx
+++ b/pages/dnd/containers.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 import { ReactNode } from "react";
+
+import { useContainerQuery } from "@cloudscape-design/component-toolkit";
+
 import classnames from "./engine.module.css";
 
 export function DefaultContainer({ children }: { children: ReactNode }) {

--- a/pages/dnd/engine-page-template.tsx
+++ b/pages/dnd/engine-page-template.tsx
@@ -1,15 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
 import ButtonDropdown from "@cloudscape-design/components/button-dropdown";
 import Header from "@cloudscape-design/components/header";
-import { useState } from "react";
+
 import { Board, BoardItem, BoardProps, ItemsPalette } from "../../lib/components";
 import { ItemsPaletteProps } from "../../src/items-palette/interfaces";
 import PageLayout from "../app/page-layout";
 import { boardI18nStrings, boardItemI18nStrings, itemsPaletteI18nStrings } from "../shared/i18n";
 import { ItemData } from "../shared/interfaces";
-import classnames from "./engine.module.css";
 import { ItemWidgets } from "./items";
+
+import classnames from "./engine.module.css";
 
 export function EnginePageTemplate({
   initialBoardItems,

--- a/pages/dnd/engine-query-test.page.tsx
+++ b/pages/dnd/engine-query-test.page.tsx
@@ -1,13 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
 import Button from "@cloudscape-design/components/button";
 import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
-import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
+
 import PageLayout from "../app/page-layout";
 import { EnginePageTemplate } from "./engine-page-template";
 import { createLetterItems, letterWidgets } from "./items";

--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -3,6 +3,7 @@
 import Box from "@cloudscape-design/components/box";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+
 import { BoardProps, ItemsPaletteProps } from "../../lib/components";
 import { fromMatrix } from "../../lib/components/internal/debug-tools";
 import { BoardItemDefinition, BoardItemDefinitionBase } from "../../lib/components/internal/interfaces";

--- a/pages/dnd/update-layout-test.page.tsx
+++ b/pages/dnd/update-layout-test.page.tsx
@@ -1,13 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import Header from "@cloudscape-design/components/header";
 import { useState } from "react";
+
+import Header from "@cloudscape-design/components/header";
+
 import { Board, BoardItem, BoardProps, ItemsPalette, ItemsPaletteProps } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { ScreenshotArea } from "../screenshot-area";
 import { boardI18nStrings, boardItemI18nStrings, itemsPaletteI18nStrings } from "../shared/i18n";
 import { ItemData } from "../shared/interfaces";
+
 import classnames from "./engine.module.css";
 
 export default function () {

--- a/pages/grid/permutations.page.tsx
+++ b/pages/grid/permutations.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import clsx from "clsx";
+
 import Grid from "../../lib/components/internal/grid";
 import { TestBed } from "../app/test-bed";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/grid/with-widget-containers-compact.page.tsx
+++ b/pages/grid/with-widget-containers-compact.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import Header from "@cloudscape-design/components/header";
+
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";

--- a/pages/grid/with-widget-containers.page.tsx
+++ b/pages/grid/with-widget-containers.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import Header from "@cloudscape-design/components/header";
+
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { TestBed } from "../app/test-bed";

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
-import "@cloudscape-design/global-styles/index.css";
 
 import App from "./app";
+
+import "@cloudscape-design/global-styles/index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>

--- a/pages/micro-frontend/integration.page.tsx
+++ b/pages/micro-frontend/integration.page.tsx
@@ -1,14 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ReactNode, useLayoutEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+
 import AppLayout from "@cloudscape-design/components/app-layout";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import SplitPanel from "@cloudscape-design/components/split-panel";
-import { ReactNode, useLayoutEffect, useRef, useState } from "react";
-import { createRoot } from "react-dom/client";
+
 import { Board, BoardItem, ItemsPalette } from "../../lib/components";
 import { createLetterItems } from "../dnd/items";
 import {

--- a/pages/shared/i18n.ts
+++ b/pages/shared/i18n.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { AppLayoutProps } from "@cloudscape-design/components/app-layout";
 import { SplitPanelProps } from "@cloudscape-design/components/split-panel";
+
 import { BoardItemProps, BoardProps, ItemsPaletteProps } from "../../lib/components";
 import { ItemData } from "./interfaces";
 

--- a/pages/widget-container/content-permutations.page.tsx
+++ b/pages/widget-container/content-permutations.page.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import Header from "@cloudscape-design/components/header";
+
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { demoWidgets } from "../dnd/items";

--- a/pages/widget-container/permutations.page.tsx
+++ b/pages/widget-container/permutations.page.tsx
@@ -5,6 +5,7 @@ import Button from "@cloudscape-design/components/button";
 import ButtonDropdown from "@cloudscape-design/components/button-dropdown";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+
 import { Board, BoardItem } from "../../lib/components";
 import PageLayout from "../app/page-layout";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/with-app-layout/app-layout.tsx
+++ b/pages/with-app-layout/app-layout.tsx
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { ReactNode, useState } from "react";
+
 import AppLayout from "@cloudscape-design/components/app-layout";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
@@ -8,7 +10,7 @@ import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import SplitPanel from "@cloudscape-design/components/split-panel";
-import { ReactNode, useState } from "react";
+
 import { appLayoutI18nStrings, clientI18nStrings, splitPanelI18nStrings } from "../shared/i18n";
 
 interface ClientAppLayoutProps {

--- a/pages/with-app-layout/delete-confirmation-modal.tsx
+++ b/pages/with-app-layout/delete-confirmation-modal.tsx
@@ -5,6 +5,7 @@ import Button from "@cloudscape-design/components/button";
 import Form from "@cloudscape-design/components/form";
 import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+
 import { clientI18nStrings } from "../shared/i18n";
 
 export function DeleteConfirmationModal({

--- a/pages/with-app-layout/integ.page.tsx
+++ b/pages/with-app-layout/integ.page.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useState } from "react";
+
 import { BoardProps } from "../../lib/components";
 import { demoBoardItems, demoPaletteItems } from "../dnd/items";
 import { ScreenshotArea } from "../screenshot-area";

--- a/pages/with-app-layout/widgets-board.tsx
+++ b/pages/with-app-layout/widgets-board.tsx
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from "react";
+
 import Box from "@cloudscape-design/components/box";
 import ButtonDropdown from "@cloudscape-design/components/button-dropdown";
 import Header from "@cloudscape-design/components/header";
-import { useState } from "react";
+
 import { Board, BoardItem, BoardProps } from "../../lib/components";
 import LiveRegion from "../../lib/components/internal/live-region";
 import { boardI18nStrings, boardItemI18nStrings, clientI18nStrings } from "../shared/i18n";

--- a/pages/with-app-layout/widgets-palette.tsx
+++ b/pages/with-app-layout/widgets-palette.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Header from "@cloudscape-design/components/header";
+
 import { BoardItem, ItemsPalette, ItemsPaletteProps } from "../../lib/components";
 import LiveRegion from "../../lib/components/internal/live-region";
 import { boardItemI18nStrings, clientI18nStrings, itemsPaletteI18nStrings } from "../shared/i18n";

--- a/src/__tests__/base-props-support.test.tsx
+++ b/src/__tests__/base-props-support.test.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render } from "@testing-library/react";
 import { ReactElement } from "react";
 import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
 import { defaultProps, wrappers } from "./default-props";
 import { getAllComponents, requireComponent } from "./utils";
 

--- a/src/__tests__/documenter.test.ts
+++ b/src/__tests__/documenter.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 import { getAllComponents, requireComponentDefinition } from "./utils";
 
 test.each<string>(getAllComponents())(`definition for %s matches the snapshot`, (componentName: string) => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 // type-only import, because in runtime it tries to access Jest globals, which do not exist
 /// <reference types="@testing-library/jest-dom" />
-import matchers from "@testing-library/jest-dom/matchers";
 import { expect } from "vitest";
+import matchers from "@testing-library/jest-dom/matchers";
 
 expect.extend(matchers);

--- a/src/board-item/__tests__/board-item-wrapper.tsx
+++ b/src/board-item/__tests__/board-item-wrapper.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from "react";
+
 import { ItemContext } from "../../../lib/components/internal/item-container";
 
 export function ItemContextWrapper({ children }: { children: ReactNode }) {

--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import Container from "@cloudscape-design/components/container";
-import { cleanup, render as libRender } from "@testing-library/react";
 import { ReactElement } from "react";
 import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render as libRender } from "@testing-library/react";
+
+import Container from "@cloudscape-design/components/container";
+
 import BoardItem from "../../../lib/components/board-item";
 import createWrapper from "../../../lib/components/test-utils/dom";
 import { ItemContextWrapper } from "./board-item-wrapper";

--- a/src/board-item/header.tsx
+++ b/src/board-item/header.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import clsx from "clsx";
 import { ReactNode } from "react";
+import clsx from "clsx";
+
 import { useVisualRefresh } from "../internal/base-component/use-visual-refresh.js";
+
 import styles from "./styles.css.js";
 
 export interface WidgetContainerHeaderProps {

--- a/src/board-item/internal.tsx
+++ b/src/board-item/internal.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import Container from "@cloudscape-design/components/container";
-import clsx from "clsx";
 import { useId } from "react";
+import clsx from "clsx";
+
+import Container from "@cloudscape-design/components/container";
+
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
 import DragHandle from "../internal/drag-handle";
@@ -11,6 +13,7 @@ import ResizeHandle from "../internal/resize-handle";
 import ScreenreaderOnly from "../internal/screenreader-only";
 import WidgetContainerHeader from "./header";
 import type { BoardItemProps } from "./interfaces";
+
 import styles from "./styles.css.js";
 
 export function InternalBoardItem({

--- a/src/board/__tests__/board-acquisition.test.tsx
+++ b/src/board/__tests__/board-acquisition.test.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { act, render, screen } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
 import { Board } from "../../../lib/components";
 import { mockController } from "../../../lib/components/internal/dnd-controller/__mocks__/controller";
 import { DragAndDropData } from "../../../lib/components/internal/dnd-controller/controller";

--- a/src/board/__tests__/board.test.tsx
+++ b/src/board/__tests__/board.test.tsx
@@ -1,15 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { KeyCode } from "@cloudscape-design/test-utils-core/utils";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import { KeyCode } from "@cloudscape-design/test-utils-core/utils";
+
 import Board from "../../../lib/components/board";
+import createWrapper from "../../../lib/components/test-utils/dom";
+import { defaultProps } from "./utils";
+
 import dragHandleStyles from "../../../lib/components/internal/drag-handle/styles.css.js";
 import globalStateStyles from "../../../lib/components/internal/global-drag-state-styles/styles.css.js";
 import resizeHandleStyles from "../../../lib/components/internal/resize-handle/styles.css.js";
-import createWrapper from "../../../lib/components/test-utils/dom";
-import { defaultProps } from "./utils";
 
 describe("Board", () => {
   beforeAll(() => {

--- a/src/board/__tests__/utils.tsx
+++ b/src/board/__tests__/utils.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import Button from "@cloudscape-design/components/button";
+
 import { BoardProps } from "../../../lib/components/board";
 import BoardItem from "../../../lib/components/board-item";
 

--- a/src/board/interfaces.ts
+++ b/src/board/interfaces.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode } from "react";
+
 import { InteractionType, Operation } from "../internal/dnd-controller/controller";
 import {
   BoardItemDefinition,

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import clsx from "clsx";
 import { ReactNode, useEffect, useRef } from "react";
+import clsx from "clsx";
+
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
 import { useContainerColumns } from "../internal/breakpoints";
@@ -24,14 +25,14 @@ import {
 import { Position } from "../internal/utils/position";
 import { useAutoScroll } from "../internal/utils/use-auto-scroll";
 import { useMergeRefs } from "../internal/utils/use-merge-refs";
-
 import { BoardProps } from "./interfaces";
 import Placeholder from "./placeholder";
-import styles from "./styles.css.js";
 import { selectTransitionRows, useTransition } from "./transition";
 import { announcementToString } from "./utils/announcements";
 import { createTransforms } from "./utils/create-transforms";
 import { createItemsChangeEvent } from "./utils/events";
+
+import styles from "./styles.css.js";
 
 export function InternalBoard<D>({
   items,

--- a/src/board/placeholder.tsx
+++ b/src/board/placeholder.tsx
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import clsx from "clsx";
 import { useRef } from "react";
+import clsx from "clsx";
+
 import { useDroppable } from "../internal/dnd-controller/controller";
 import { GridContext } from "../internal/grid/interfaces";
 import { BoardItemDefinitionBase } from "../internal/interfaces";
 import { getDefaultColumnSpan, getDefaultRowSpan } from "../internal/utils/layout";
+
 import styles from "./styles.css.js";
 
 export type PlaceholderState = "default" | "active" | "hover";

--- a/src/board/transition.ts
+++ b/src/board/transition.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { Dispatch, ReactNode, useReducer } from "react";
+
 import { InteractionType, Operation } from "../internal/dnd-controller/controller";
 import { BoardItemDefinitionBase, Direction, GridLayout, ItemId, Rect } from "../internal/interfaces";
 import { LayoutEngine } from "../internal/layout-engine/engine";

--- a/src/board/utils/__tests__/layout.test.ts
+++ b/src/board/utils/__tests__/layout.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix } from "../../../internal/debug-tools";
 import { Operation } from "../../../internal/dnd-controller/controller";
 import { GridLayout } from "../../../internal/interfaces";

--- a/src/board/utils/__tests__/path.test.ts
+++ b/src/board/utils/__tests__/path.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
-import { Position } from "../../../internal/utils/position";
 
+import { Position } from "../../../internal/utils/position";
 import { appendMovePath, appendResizePath, normalizeInsertionPath } from "../path";
 
 describe("normalizeInsertionPath", () => {

--- a/src/internal/base-component/use-base-component.ts
+++ b/src/internal/base-component/use-base-component.ts
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { MutableRefObject } from "react";
+
 import {
   ComponentConfiguration,
   initAwsUiVersions,
   useComponentMetadata,
 } from "@cloudscape-design/component-toolkit/internal";
-import { MutableRefObject } from "react";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION } from "../environment";
 import { useTelemetry } from "./use-telemetry";
 

--- a/src/internal/base-component/use-telemetry.ts
+++ b/src/internal/base-component/use-telemetry.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ComponentConfiguration, useComponentMetrics } from "@cloudscape-design/component-toolkit/internal";
+
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from "../environment";
 import { useVisualRefresh } from "./use-visual-refresh";
 

--- a/src/internal/base-component/use-visual-refresh.ts
+++ b/src/internal/base-component/use-visual-refresh.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRuntimeVisualRefresh } from "@cloudscape-design/component-toolkit/internal";
+
 import { ALWAYS_VISUAL_REFRESH } from "../environment";
 
 export const useVisualRefresh = ALWAYS_VISUAL_REFRESH ? () => true : useRuntimeVisualRefresh;

--- a/src/internal/dnd-controller/__mocks__/controller.ts
+++ b/src/internal/dnd-controller/__mocks__/controller.ts
@@ -3,6 +3,7 @@
 
 import { useEffect } from "react";
 import { vi } from "vitest";
+
 import { AcquireData, DragAndDropData, DragAndDropEvents } from "../controller";
 import { EventEmitter } from "../event-emitter";
 

--- a/src/internal/dnd-controller/controller.ts
+++ b/src/internal/dnd-controller/controller.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useStableCallback } from "@cloudscape-design/component-toolkit/internal";
 import { ReactNode, useEffect } from "react";
+
+import { useStableCallback } from "@cloudscape-design/component-toolkit/internal";
+
 import { BoardItemDefinitionBase, ItemId, Rect } from "../interfaces";
 import { Coordinates } from "../utils/coordinates";
 import { EventEmitter } from "./event-emitter";

--- a/src/internal/drag-handle/index.tsx
+++ b/src/internal/drag-handle/index.tsx
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import Icon from "@cloudscape-design/components/icon";
+import { ForwardedRef, forwardRef, KeyboardEvent, PointerEvent } from "react";
 import clsx from "clsx";
-import { ForwardedRef, KeyboardEvent, PointerEvent, forwardRef } from "react";
+
+import Icon from "@cloudscape-design/components/icon";
 
 import Handle from "../handle";
+
 import styles from "./styles.css.js";
 
 export interface DragHandleProps {

--- a/src/internal/global-drag-state-styles/index.ts
+++ b/src/internal/global-drag-state-styles/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { DragAndDropData, useDragSubscription } from "../dnd-controller/controller";
+
 import styles from "./styles.css.js";
 
 function assertNever(value: never) {

--- a/src/internal/grid/__tests__/grid.test.tsx
+++ b/src/internal/grid/__tests__/grid.test.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { render } from "@testing-library/react";
 import { expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
 import Grid, { GridProps } from "../../../../lib/components/internal/grid";
+
 import gridStyles from "../../../../lib/components/internal/grid/styles.css.js";
 
 const defaultProps: GridProps = {

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -1,15 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Children, useRef } from "react";
+import clsx from "clsx";
+
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 import { useDensityMode } from "@cloudscape-design/component-toolkit/internal";
-import clsx from "clsx";
-import { Children, useRef } from "react";
+
 import { useMergeRefs } from "../utils/use-merge-refs";
 import { zipTwoArrays } from "../utils/zip-arrays";
-
 import { GridProps } from "./interfaces";
 import GridItem from "./item";
+
 import styles from "./styles.css.js";
 
 /* Matches grid gap in CSS. */

--- a/src/internal/grid/interfaces.ts
+++ b/src/internal/grid/interfaces.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ReactNode } from "react";
+
 import { GridLayoutItem } from "../interfaces";
 
 export interface GridProps {

--- a/src/internal/grid/item.tsx
+++ b/src/internal/grid/item.tsx
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode, memo } from "react";
+import { memo, ReactNode } from "react";
+
 import { GridLayoutItem } from "../interfaces";
+
 import styles from "./styles.css.js";
 
 export interface GridItemProps {

--- a/src/internal/handle/index.tsx
+++ b/src/internal/handle/index.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { ButtonHTMLAttributes, ForwardedRef, forwardRef, PointerEvent } from "react";
 import clsx from "clsx";
-import { ButtonHTMLAttributes, ForwardedRef, PointerEvent, forwardRef } from "react";
+
 import styles from "./styles.css.js";
 
 function Handle(props: ButtonHTMLAttributes<HTMLButtonElement>, ref: ForwardedRef<HTMLButtonElement>) {

--- a/src/internal/item-container/__tests__/get-next-droppable.test.ts
+++ b/src/internal/item-container/__tests__/get-next-droppable.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 import { Droppable } from "../../../../lib/components/internal/dnd-controller/controller";
 import { Rect } from "../../../../lib/components/internal/interfaces";
 import { getNextDroppable } from "../../../../lib/components/internal/item-container/get-next-droppable";

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+
 import { mockController, mockDraggable } from "../../../../lib/components/internal/dnd-controller/__mocks__/controller";
 import { DragAndDropData } from "../../../../lib/components/internal/dnd-controller/controller";
 import { ItemContainer, ItemContainerProps, useItemContext } from "../../../../lib/components/internal/item-container";

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -1,16 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { CSS as CSSUtil } from "@dnd-kit/utilities";
-import clsx from "clsx";
 import {
+  createContext,
   CSSProperties,
+  forwardRef,
   KeyboardEvent,
-  ReactNode,
   PointerEvent as ReactPointerEvent,
+  ReactNode,
   Ref,
   RefObject,
-  createContext,
-  forwardRef,
   useContext,
   useEffect,
   useImperativeHandle,
@@ -18,13 +16,16 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import clsx from "clsx";
+import { CSS as CSSUtil } from "@dnd-kit/utilities";
+
 import {
   DragAndDropData,
   DropTargetContext,
   InteractionType,
   Operation,
-  useDragSubscription,
   useDraggable,
+  useDragSubscription,
 } from "../dnd-controller/controller";
 import { BoardItemDefinitionBase, Direction, ItemId, Transform } from "../interfaces";
 import { Coordinates } from "../utils/coordinates";
@@ -32,6 +33,7 @@ import { getNormalizedElementRect } from "../utils/screen";
 import { throttle } from "../utils/throttle";
 import { getCollisionRect } from "./get-collision-rect";
 import { getNextDroppable } from "./get-next-droppable";
+
 import styles from "./styles.css.js";
 
 export interface ItemContainerRef {

--- a/src/internal/layout-engine/__tests__/engine-cache.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-cache.test.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from "vitest";
+
 import { generateGrid, generateInsert, generateMove, generateResize } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
-import { Measure, forEachTimes } from "./helpers";
+import { forEachTimes, Measure } from "./helpers";
 
 const TOTAL_RUNS = 100;
 const AVERAGE_EXECUTION_TIME_MS = 1;

--- a/src/internal/layout-engine/__tests__/engine-convergence.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-convergence.test.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from "vitest";
+
 import { generateGrid, generateInsert, generateMove, generateResize } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
-import { Measure, forEachTimes } from "./helpers";
+import { forEachTimes, Measure } from "./helpers";
 
 const TOTAL_RUNS = 1000;
 const AVERAGE_EXECUTION_TIME_MS = 3;

--- a/src/internal/layout-engine/__tests__/engine-float.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-float.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from "vitest";
+
 import { fromMatrix, fromTextPath, generateGrid, generateMove, toMatrix } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
 import { forEachTimes } from "./helpers";

--- a/src/internal/layout-engine/__tests__/engine-immutable.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-immutable.test.ts
@@ -3,6 +3,7 @@
 
 import { cloneDeep } from "lodash";
 import { expect, test } from "vitest";
+
 import { generateGrid, generateMove, generateResize } from "../../debug-tools";
 import { Position } from "../../utils/position";
 import { LayoutEngine } from "../engine";

--- a/src/internal/layout-engine/__tests__/engine-insert.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-insert.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, generateGrid, generateInsert, toString } from "../../debug-tools";
 import { Position } from "../../utils/position";
 import { LayoutEngine } from "../engine";

--- a/src/internal/layout-engine/__tests__/engine-move-1x1-items.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-move-1x1-items.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, fromTextPath, toString } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
 

--- a/src/internal/layout-engine/__tests__/engine-move-blocks.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-move-blocks.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, fromTextPath, generateGrid, generateMove, toString } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
 import { forEachTimes } from "./helpers";

--- a/src/internal/layout-engine/__tests__/engine-move-larger.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-move-larger.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, fromTextPath, toString } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
 

--- a/src/internal/layout-engine/__tests__/engine-remove.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-remove.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, generateGrid, toString } from "../../debug-tools";
 import { LayoutEngine } from "../engine";
 import { forEachTimes } from "./helpers";

--- a/src/internal/layout-engine/__tests__/engine-resize.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-resize.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, generateGrid, generateRandomPath, generateResize, toString } from "../../debug-tools";
 import { Position } from "../../utils/position";
 import { LayoutEngine } from "../engine";

--- a/src/internal/layout-engine/__tests__/engine-validation.test.ts
+++ b/src/internal/layout-engine/__tests__/engine-validation.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from "vitest";
+
 import { fromMatrix, fromTextPath } from "../../debug-tools";
 import { Position } from "../../utils/position";
 import { LayoutEngine } from "../engine";

--- a/src/internal/layout-engine/engine-step.ts
+++ b/src/internal/layout-engine/engine-step.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Position } from "../utils/position";
-import { MoveSolution, MoveSolutionState, findNextSolutions } from "./engine-solution";
+import { findNextSolutions, MoveSolution, MoveSolutionState } from "./engine-solution";
 import { Conflicts, LayoutEngineState } from "./engine-state";
 import { ReadonlyLayoutEngineGrid } from "./grid";
 import { CommittedMove } from "./interfaces";

--- a/src/internal/live-region/index.tsx
+++ b/src/internal/live-region/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { memo, useEffect, useRef } from "react";
+
 import ScreenreaderOnly, { ScreenreaderOnlyProps } from "../screenreader-only";
 
 // The code is copied from https://github.com/cloudscape-design/components/blob/main/src/internal/components/live-region/index.tsx

--- a/src/internal/resize-handle/index.tsx
+++ b/src/internal/resize-handle/index.tsx
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import Icon from "@cloudscape-design/components/icon";
-import clsx from "clsx";
 import { KeyboardEvent, PointerEvent } from "react";
+import clsx from "clsx";
+
+import Icon from "@cloudscape-design/components/icon";
+
 import Handle from "../handle";
+
 import styles from "./styles.css.js";
 
 export interface ResizeHandleProps {

--- a/src/internal/screenreader-grid-navigation/__tests__/screenreader-grid-navigation.test.tsx
+++ b/src/internal/screenreader-grid-navigation/__tests__/screenreader-grid-navigation.test.tsx
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { cleanup, render } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
 import { GridLayout } from "../../../../lib/components/internal/interfaces";
 import { ScreenReaderGridNavigation } from "../../../../lib/components/internal/screenreader-grid-navigation";
 

--- a/src/internal/screenreader-grid-navigation/index.tsx
+++ b/src/internal/screenreader-grid-navigation/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useId, useMemo, useState } from "react";
+
 import { GridLayout, ItemId } from "../interfaces";
 import ScreenreaderOnly from "../screenreader-only";
 

--- a/src/internal/screenreader-only/index.tsx
+++ b/src/internal/screenreader-only/index.tsx
@@ -4,6 +4,7 @@
 // The code is copied from https://github.com/cloudscape-design/components/blob/main/src/internal/components/screenreader-only/index.tsx
 
 import clsx from "clsx";
+
 import styles from "./styles.css.js";
 
 export interface ScreenreaderOnlyProps {

--- a/src/internal/utils/__tests__/layout.test.ts
+++ b/src/internal/utils/__tests__/layout.test.ts
@@ -3,6 +3,7 @@
 
 import deepFreeze from "deep-freeze-es6";
 import { describe, expect, test } from "vitest";
+
 import { fromMatrix, toString } from "../../debug-tools";
 import { BoardItemColumnOffset, BoardItemDefinition, BoardItemDefinitionBase } from "../../interfaces";
 import {

--- a/src/internal/utils/__tests__/rects.test.ts
+++ b/src/internal/utils/__tests__/rects.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+
 import { getClosestNeighbor, getGridPlacement, isInside, isIntersecting } from "../rects";
 
 const grid = [

--- a/src/internal/utils/__tests__/throttle.test.ts
+++ b/src/internal/utils/__tests__/throttle.test.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Mock, SpyInstance, afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, Mock, SpyInstance, test, vi } from "vitest";
+
 import { throttle } from "../throttle";
 
 describe("throttle", () => {

--- a/src/internal/utils/__tests__/zip-arrays.test.ts
+++ b/src/internal/utils/__tests__/zip-arrays.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect, test } from "vitest";
+
 import { zipTwoArrays } from "../zip-arrays";
 
 test("zips arrays of same lengths", () => {

--- a/src/internal/utils/use-auto-scroll.ts
+++ b/src/internal/utils/use-auto-scroll.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useRef, useState } from "react";
+
 import { useLastInteraction } from "./use-last-interaction";
 
 export function useAutoScroll() {

--- a/src/items-palette/__tests__/palette.test.tsx
+++ b/src/items-palette/__tests__/palette.test.tsx
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { act, cleanup, render as libRender } from "@testing-library/react";
 import { ReactElement } from "react";
 import { afterEach, expect, test, vi } from "vitest";
-import itemStyles from "../../../lib/components/board-item/styles.css.js";
+import { act, cleanup, render as libRender } from "@testing-library/react";
+
 import { mockController } from "../../../lib/components/internal/dnd-controller/__mocks__/controller";
 import ItemsPalette, { ItemsPaletteProps } from "../../../lib/components/items-palette";
 import createWrapper, { ItemsPaletteWrapper } from "../../../lib/components/test-utils/dom";
+
+import itemStyles from "../../../lib/components/board-item/styles.css.js";
 
 afterEach(cleanup);
 

--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useRef, useState } from "react";
+
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
 import { useDragSubscription } from "../internal/dnd-controller/controller";
@@ -10,6 +12,7 @@ import { ItemContainer, ItemContainerRef } from "../internal/item-container";
 import LiveRegion from "../internal/live-region";
 import { ScreenReaderGridNavigation } from "../internal/screenreader-grid-navigation";
 import { ItemsPaletteProps } from "./interfaces";
+
 import styles from "./styles.css.js";
 
 export function InternalItemsPalette<D>({

--- a/src/test-utils/dom/board-item/index.ts
+++ b/src/test-utils/dom/board-item/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import componentsWrapper from "@cloudscape-design/components/test-utils/dom";
 import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+
 import itemStyles from "../../../board-item/styles.selectors.js";
 import dragHandleStyles from "../../../internal/drag-handle/styles.selectors.js";
 import resizeHandleStyles from "../../../internal/resize-handle/styles.selectors.js";

--- a/src/test-utils/dom/board/index.ts
+++ b/src/test-utils/dom/board/index.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper, createWrapper } from "@cloudscape-design/test-utils-core/dom";
-import boardStyles from "../../../board/styles.selectors.js";
+
 import BoardItemWrapper from "../board-item";
+
+import boardStyles from "../../../board/styles.selectors.js";
 
 export default class BoardWrapper extends ComponentWrapper {
   static rootSelector: string = boardStyles.root;

--- a/src/test-utils/dom/items-palette/index.ts
+++ b/src/test-utils/dom/items-palette/index.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
-import paletteStyles from "../../../items-palette/styles.selectors.js";
+
 import PaletteItemWrapper from "../palette-item";
+
+import paletteStyles from "../../../items-palette/styles.selectors.js";
 
 export default class ItemsPaletteWrapper extends ComponentWrapper {
   static rootSelector: string = paletteStyles.root;

--- a/src/test-utils/dom/palette-item/index.ts
+++ b/src/test-utils/dom/palette-item/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+
 import itemStyles from "../../../board-item/styles.selectors.js";
 import dragHandleStyles from "../../../internal/drag-handle/styles.selectors.js";
 

--- a/test/functional/board-layout/conditional-editing.test.ts
+++ b/test/functional/board-layout/conditional-editing.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test } from "vitest";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";

--- a/test/functional/board-layout/dnd-page-object.ts
+++ b/test/functional/board-layout/dnd-page-object.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { BasePageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import boardStyles from "../../../lib/components/board/styles.selectors.js";
 
 interface ExtendedWindow extends Window {

--- a/test/functional/board-layout/item-actions.test.ts
+++ b/test/functional/board-layout/item-actions.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test } from "vitest";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";

--- a/test/functional/board-layout/keyboard-interactions.test.ts
+++ b/test/functional/board-layout/keyboard-interactions.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test } from "vitest";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { makeQueryUrl, setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";

--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
-import boardStyles from "../../../lib/components/board/styles.selectors.js";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { makeQueryUrl, setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";
+
+import boardStyles from "../../../lib/components/board/styles.selectors.js";
 
 const boardWrapper = createWrapper().findBoard();
 const itemsPaletteWrapper = createWrapper().findItemsPalette();

--- a/test/functional/board-layout/live-announcements.test.ts
+++ b/test/functional/board-layout/live-announcements.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";

--- a/test/functional/board-layout/mouse-interactions.test.ts
+++ b/test/functional/board-layout/mouse-interactions.test.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { expect, test } from "vitest";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { makeQueryUrl, setupTest } from "../../utils";
 import { DndPageObject } from "./dnd-page-object";

--- a/test/functional/widget-container/keyboard.test.ts
+++ b/test/functional/widget-container/keyboard.test.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import { expect, test } from "vitest";
+
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import createWrapper from "../../../lib/components/test-utils/selectors";
 import { setupTest } from "../../utils";
 

--- a/test/visual-test-setup.ts
+++ b/test/visual-test-setup.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { join } from "path";
 import { configureToMatchImageSnapshot } from "jest-image-snapshot";
+import { join } from "path";
 import { expect } from "vitest";
 
 const snapshotDir = join(__dirname, "./..", process.env.VISUAL_REGRESSION_SNAPSHOT_DIRECTORY ?? "__image_snapshots__");

--- a/test/visual/drag-states.test.ts
+++ b/test/visual/drag-states.test.ts
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import { expect, test } from "vitest";
+
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import createWrapper from "../../lib/components/test-utils/selectors";
 import { makeQueryUrl, setupTest } from "../utils";
 

--- a/test/visual/index.test.ts
+++ b/test/visual/index.test.ts
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import path from "path";
-import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
 import { expect, test } from "vitest";
+
+import { ScreenshotPageObject } from "@cloudscape-design/browser-test-tools/page-objects";
+
 import { setupTest } from "../utils";
 
 const pagesMap = import.meta.glob("../../pages/**/*.page.tsx", { as: "raw" });


### PR DESCRIPTION
### Description

Introduced a new plugin to group and alphabetically sort imports in the following order:

external packages
cloudscape packages
internal imports
styles

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
