### PR TITLE
chore: Focus immediately when remove transition starts

### DIFF
--- a/pages/dnd/engine-a2p-test-async.page.tsx
+++ b/pages/dnd/engine-a2p-test-async.page.tsx
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EnginePageTemplate } from "./engine-page-template";
+import { createLetterItems, letterWidgets } from "./items";
+
+const letterItems = createLetterItems([
+  ["A", "B", "C", "D"],
+  ["E", "F", "G", "H"],
+  ["I", "J", "K", "L"],
+  ["M", "N", "O", "P"],
+])!;
+
+export default function () {
+  return (
+    <EnginePageTemplate
+      asyncOnChangeItems={true}
+      initialBoardItems={letterItems.boardItems}
+      initialPaletteItems={letterItems.paletteItems}
+      widgets={letterWidgets}
+    />
+  );
+}

--- a/pages/dnd/engine-page-template.tsx
+++ b/pages/dnd/engine-page-template.tsx
@@ -19,11 +19,13 @@ export function EnginePageTemplate({
   initialPaletteItems,
   widgets,
   layout = "grid",
+  asyncOnChangeItems = false,
 }: {
   initialBoardItems: readonly BoardProps.Item<ItemData>[];
   initialPaletteItems: readonly ItemsPaletteProps.Item<ItemData>[];
   widgets: ItemWidgets;
   layout?: "grid" | "absolute";
+  asyncOnChangeItems?: boolean;
 }) {
   const [boardItems, setBoardItems] = useState(initialBoardItems);
   const [paletteItems, setPaletteItems] = useState(initialPaletteItems);
@@ -53,7 +55,13 @@ export function EnginePageTemplate({
             </BoardItem>
           )}
           onItemsChange={({ detail: { items, addedItem, removedItem } }) => {
-            setBoardItems(items);
+            if (asyncOnChangeItems) {
+              setTimeout(() => {
+                setBoardItems(items);
+              }, 50);
+            } else {
+              setBoardItems(items);
+            }
             if (addedItem) {
               setPaletteItems((paletteItems) => paletteItems.filter((item) => item.id !== addedItem.id));
             }

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -111,7 +111,6 @@ export function InternalBoard<D>({
         nextIndexToFocus = items.length - 2;
       }
 
-      // Focus immediately if a valid index is found.
       if (nextIndexToFocus >= 0 && items[nextIndexToFocus]) {
         const focusTarget = items[nextIndexToFocus].id;
         if (itemContainerRef.current[focusTarget]) {

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -81,14 +81,13 @@ export function InternalBoard<D>({
   items = [...items].sort((a, b) => (layoutItemIndexById.get(a.id) ?? -1) - (layoutItemIndexById.get(b.id) ?? -1));
 
   // When an item gets acquired or removed the focus needs to be dispatched on the next render.
-  const focusNextRenderIndexRef = useRef<null | number>(null);
-
+  const focusNextRenderIdRef = useRef<null | ItemId>(null);
   useEffect(() => {
-    const focusTarget = items[focusNextRenderIndexRef.current ?? -1]?.id;
+    const focusTarget = focusNextRenderIdRef.current;
     if (focusTarget) {
       itemContainerRef.current[focusTarget].focusDragHandle();
     }
-    focusNextRenderIndexRef.current = null;
+    focusNextRenderIdRef.current = null;
   });
 
   // Submit scheduled removal after a delay to let animations play.
@@ -189,7 +188,7 @@ export function InternalBoard<D>({
     autoScrollHandlers.removePointerEventHandlers();
   });
 
-  useDragSubscription("acquire", ({ droppableId, renderAcquiredItem }) => {
+  useDragSubscription("acquire", ({ droppableId, draggableItem, renderAcquiredItem }) => {
     const placeholder = placeholdersLayout.items.find((it) => it.id === droppableId);
 
     // If missing then it does not belong to this board.
@@ -203,6 +202,7 @@ export function InternalBoard<D>({
       layoutElement: containerAccessRef.current!,
       acquiredItemElement: renderAcquiredItem(),
     });
+    focusNextRenderIdRef.current = draggableItem.id;
   });
 
   const removeItemAction = (removedItem: BoardItemDefinition<D>) => {

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -102,14 +102,30 @@ export function InternalBoard<D>({
       dispatch({ type: "submit" });
 
       const removedItemIndex = items.findIndex((it) => it.id === removeTransition.removedItem.id);
-      const nextIndexToFocus = removedItemIndex !== items.length - 1 ? removedItemIndex : items.length - 2;
-      focusNextRenderIndexRef.current = nextIndexToFocus;
+      let nextIndexToFocus = -1;
+      if (removedItemIndex === 0) {
+        nextIndexToFocus = 0;
+      } else if (removedItemIndex > 0 && removedItemIndex < items.length - 1) {
+        nextIndexToFocus = removedItemIndex - 1;
+      } else if (removedItemIndex === items.length - 1) {
+        nextIndexToFocus = items.length - 2;
+      }
+
+      // Focus immediately if a valid index is found.
+      if (nextIndexToFocus >= 0 && items[nextIndexToFocus]) {
+        const focusTarget = items[nextIndexToFocus].id;
+        if (itemContainerRef.current[focusTarget]) {
+          itemContainerRef.current[focusTarget].focusDragHandle();
+        }
+      }
+
       onItemsChange(createItemsChangeEvent(items, removeTransition.layoutShift));
     }, TRANSITION_DURATION_MS);
 
     return () => clearTimeout(timeoutId);
   }, [removeTransition, items, onItemsChange]);
-
+  // if items length changed and we were already focusing a board item handler, this can mean
+  // we can focus the next one?
   const rows = selectTransitionRows(transitionState) || itemsLayout.rows;
   const placeholdersLayout = createPlaceholdersLayout(rows, itemsLayout.columns);
 

--- a/test/functional/board-layout/item-actions.test.ts
+++ b/test/functional/board-layout/item-actions.test.ts
@@ -10,38 +10,41 @@ const boardWrapper = createWrapper().findBoard();
 const boardItemHandle = (id: string) => boardWrapper.findItemById(id).findDragHandle().toSelector();
 
 describe("items removal", () => {
-  test(
-    "focus is transitioned after non-last item removal",
-    setupTest("/index.html#/dnd/engine-a2p-test", DndPageObject, async (page) => {
-      // Remove Widget F.
-      await page.focus(boardItemHandle("F"));
-      await page.keys(["Tab", "Enter", "Enter"]);
-      await page.pause(200);
+  for (const isAsync of [true, false]) {
+    const pageUrl = isAsync ? "dnd/engine-a2p-test" : "dnd/engine-a2p-test-async";
+    test(
+      `focus is transitioned after non-last item removal ${isAsync ? "with async onItemsChange" : ""}`,
+      setupTest(`/index.html#/${pageUrl}`, DndPageObject, async (page) => {
+        // Remove Widget F.
+        await page.focus(boardItemHandle("F"));
+        await page.keys(["Tab", "Enter", "Enter"]);
+        await page.pause(200);
 
-      // Remove Widget J.
-      await page.keys(["Tab", "Enter", "Enter"]);
-      await page.pause(200);
+        // Remove Widget J.
+        await page.keys(["Tab", "Enter", "Enter"]);
+        await page.pause(200);
 
-      // Remove Widget N.
-      await page.keys(["Tab", "Enter", "Enter"]);
-      await page.pause(200);
+        // Remove Widget N.
+        await page.keys(["Tab", "Enter", "Enter"]);
+        await page.pause(200);
 
-      // Remove Widget G.
-      await page.keys(["Tab", "Enter", "Enter"]);
-      await page.pause(200);
+        // Remove Widget G.
+        await page.keys(["Tab", "Enter", "Enter"]);
+        await page.pause(200);
 
-      await expect(page.getGrid()).resolves.toEqual([
-        ["A", "B", "C", "D"],
-        ["A", "B", "C", "D"],
-        ["E", " ", "K", "H"],
-        ["E", " ", "K", "H"],
-        ["I", " ", "O", "L"],
-        ["I", " ", "O", "L"],
-        ["M", " ", " ", "P"],
-        ["M", " ", " ", "P"],
-      ]);
-    }),
-  );
+        await expect(page.getGrid()).resolves.toEqual([
+          ["A", "B", "C", "D"],
+          ["A", "B", "C", "D"],
+          ["E", " ", "K", "H"],
+          ["E", " ", "K", "H"],
+          ["I", " ", "O", "L"],
+          ["I", " ", "O", "L"],
+          ["M", " ", " ", "P"],
+          ["M", " ", " ", "P"],
+        ]);
+      }),
+    );
+  }
 
   test(
     "focus is transitioned after last item removal",


### PR DESCRIPTION
### Description

In case consumers executed the `actions.removeItem()` and implemented the items update logic inside the `onItemsChange` in async mode the focus gets lost because in our code we always assume that after the `removeItem` exection the items will be updated.

This code fixes that by not depending on a use effect and just immediately focuses the next item.

<!-- Also include relevant motivation and context. -->

issues/AWSUI-47888

### How has this been tested?

Added a functional test and a new page with the async behavior simulation (using `setTimeout()`.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
