### PR TITLE
fix: Fix drag handle focus after item acquisition

### DIFF
--- a/src/board/__tests__/board-acquisition.test.tsx
+++ b/src/board/__tests__/board-acquisition.test.tsx
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
 import { act, render, screen } from "@testing-library/react";
 import { expect, test, vi } from "vitest";
 
-import { Board } from "../../../lib/components";
+import { Board, BoardProps } from "../../../lib/components";
 import { mockController } from "../../../lib/components/internal/dnd-controller/__mocks__/controller";
 import { DragAndDropData } from "../../../lib/components/internal/dnd-controller/controller";
 import { Coordinates } from "../../../lib/components/internal/utils/coordinates";
+import createWrapper from "../../../lib/components/test-utils/dom";
 import { defaultProps } from "./utils";
 
 vi.mock("../../../lib/components/internal/dnd-controller/controller");
@@ -37,4 +39,35 @@ test("renders acquired item", () => {
 
   act(() => mockController.discard());
   expect(screen.queryByTestId("acquired-item")).toBeNull();
+});
+
+function StatefulBoard(props: BoardProps<{ title: string }>) {
+  const [items, setItems] = useState(props.items);
+  return <Board {...props} items={items} onItemsChange={({ detail }) => setItems(detail.items)} />;
+}
+
+test("focuses on acquired item's drag handle upon submission", () => {
+  render(<StatefulBoard {...defaultProps} />);
+  const draggableItem = { id: "test", data: { title: "Test item" }, definition: {} };
+
+  act(() =>
+    mockController.start({
+      interactionType: "keyboard",
+      operation: "insert",
+      draggableItem,
+      collisionRect: { top: 0, bottom: 0, left: 0, right: 0 },
+      coordinates: new Coordinates({ x: 0, y: 0 }),
+    } as DragAndDropData),
+  );
+
+  act(() =>
+    mockController.acquire({
+      droppableId: "awsui-placeholder-1-0",
+      draggableItem,
+      renderAcquiredItem: () => <div></div>,
+    }),
+  );
+
+  act(() => mockController.submit());
+  expect(createWrapper().findBoard()!.findItemById("test")!.findDragHandle().getElement()).toHaveFocus();
 });

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { ReactNode, useEffect, useRef } from "react";
+import { usePrevious } from "@dnd-kit/utilities";
 import clsx from "clsx";
 
 import { getIsRtl } from "@cloudscape-design/component-toolkit/internal";
@@ -112,6 +113,17 @@ export function InternalBoard<D>({
 
     return () => clearTimeout(timeoutId);
   }, [removeTransition, items, onItemsChange]);
+
+  // When item is inserting with the keyboard it keeps rendering by the palette and upon submission
+  // it starts rendering by the board. This transitions might lead to the focus being lost from the item's drag handle.
+  // The below code refocuses the drag handle when detecting the acquired item is no longer used.
+  const acquiredItemId = usePrevious(acquiredItem?.id);
+  const previousAcquiredItemElement = usePrevious(acquiredItemElement);
+  useEffect(() => {
+    if (acquiredItemId && previousAcquiredItemElement && !acquiredItemElement) {
+      itemContainerRef.current[acquiredItemId]?.focusDragHandle();
+    }
+  }, [acquiredItemId, previousAcquiredItemElement, acquiredItemElement]);
 
   const rows = selectTransitionRows(transitionState) || itemsLayout.rows;
   const placeholdersLayout = createPlaceholdersLayout(rows, itemsLayout.columns);


### PR DESCRIPTION
### Description

When acquiring item with keyboard the focus can get lost upon submission due to rendering function change. The new refocusing logic mitigates that.

Rel: AWSUI-54391

### How has this been tested?

* New unit test that secures the regression
* Manually tested with demos

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
