### PR TITLE
fix: Makes board item test utils wrappers chainable

### DIFF
--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -1,11 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import { ReactElement } from "react";
 import { cleanup, render as libRender } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 
+import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
+import ExpandableSection from "@cloudscape-design/components/expandable-section";
+import Header from "@cloudscape-design/components/header";
 
+import "@cloudscape-design/components/test-utils/dom";
 import BoardItem from "../../../lib/components/board-item";
 import createWrapper from "../../../lib/components/test-utils/dom";
 import { ItemContextWrapper } from "./board-item-wrapper";
@@ -32,16 +37,22 @@ describe("WidgetContainer", () => {
         <Container header="Container header" footer="Container footer">
           Container content
         </Container>
-        <BoardItem header="Header" footer="Footer" settings="Settings" i18nStrings={i18nStrings}>
-          Content
+        <BoardItem
+          header={<Header>Header</Header>}
+          footer={<ExpandableSection headerText="Footer">Footer expandable content</ExpandableSection>}
+          settings={<Button iconName="settings" ariaLabel="Settings" />}
+          i18nStrings={i18nStrings}
+        >
+          Content <Button>Action</Button>
         </BoardItem>
       </div>,
     );
+
     const itemWrapper = createWrapper().findBoardItem()!;
-    expect(itemWrapper.findHeader()!.getElement().textContent).toBe("Header");
-    expect(itemWrapper.findContent().getElement().textContent).toBe("Content");
-    expect(itemWrapper.findFooter()!.getElement().textContent).toBe("Footer");
-    expect(itemWrapper.findSettings()!.getElement().textContent).toBe("Settings");
+    expect(itemWrapper.findHeader()!.findHeader()!.getElement()).toHaveTextContent("Header");
+    expect(itemWrapper.findContent()!.findButton()!.getElement()).toHaveTextContent("Action");
+    expect(itemWrapper.findFooter()!.findExpandableSection()!.findHeader()!.getElement()).toHaveTextContent("Footer");
+    expect(itemWrapper.findSettings()!.findButton()!.getElement()).toHaveAccessibleName("Settings");
   });
 
   test("renders handle aria labels", () => {

--- a/src/test-utils/dom/board-item/index.ts
+++ b/src/test-utils/dom/board-item/index.ts
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
 import componentsWrapper from "@cloudscape-design/components/test-utils/dom";
-import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+import { ComponentWrapper, ElementWrapper } from "@cloudscape-design/test-utils-core/dom";
 
 import itemStyles from "../../../board-item/styles.selectors.js";
 import dragHandleStyles from "../../../internal/drag-handle/styles.selectors.js";
@@ -18,21 +19,21 @@ export default class BoardItemWrapper extends ComponentWrapper {
     return this.findByClassName(resizeHandleStyles.handle)!;
   }
 
-  findSettings(): null | ComponentWrapper {
+  findSettings(): null | ElementWrapper {
     return this.findByClassName(itemStyles.settings);
   }
 
   // @cloudscape-design/components/container methods
 
-  findHeader(): null | ComponentWrapper {
+  findHeader(): null | ElementWrapper {
     return this.findByClassName(itemStyles["header-content"]);
   }
 
-  findContent(): ComponentWrapper {
+  findContent(): ElementWrapper {
     return componentsWrapper(this.getElement()).findContainer()!.findContent();
   }
 
-  findFooter(): null | ComponentWrapper {
+  findFooter(): null | ElementWrapper {
     return componentsWrapper(this.getElement()).findContainer()!.findFooter();
   }
 }


### PR DESCRIPTION
### Description

Board item has slots and those must return ElementWrapper and not ContentWrapper so that it is possible to chain selectors like `createWrapper().findBoardItem().findContent().findButton()`. That requires respective components selectors to be imported e.g. `import "@cloudscape-design/components/test-utils/dom"` or `import "@cloudscape-design/code-view/test-utils/dom"`.

### How has this been tested?

* New unit tests

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
