### PR TITLE
chore: Make window taller in test to avoid scrollbars

### DIFF
--- a/test/functional/board-layout/layout.test.ts
+++ b/test/functional/board-layout/layout.test.ts
@@ -27,6 +27,7 @@ test(
     ),
     DndPageObject,
     async (page) => {
+      await page.setWindowSize({ width: 1600, height: 1200 });
       await page.mouseDown(boardWrapper.findItemById("A").findDragHandle().toSelector());
       await expect(page.getGrid()).resolves.toEqual([
         ["A", "B", "C", "D"],


### PR DESCRIPTION
### Description

We want to show scrollbars in tests but one test in board-components fails when doing that ([dry-run](https://github.com/cloudscape-design/browser-test-tools/actions/runs/11796000980/job/32868652896?pr=120)). This is because as the element is dragged, grid placeholders are added below, which causes a scrollbar to appear and the page content slightly moves to the left. Then, the test, which compares the dragged element's position against the placeholders, does not find it exactly where it expects.

I don't think this is really a bug, rather expected behavior given how browsers work. Therefore fixing in the test.

### How has this been tested?

Used [this approach](https://github.com/cloudscape-design/components/pull/3002/files#diff-596d348eb0961ab3457c7941e2c60330639c21a43f1e2e96d3759016adb58eea) to show scrollbars locally. Ran the changed test before the changes and it failed, and after the changes it passed.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
