### PR TITLE
feat: Use column layout in items palette

### DIFF
--- a/src/items-palette/internal.tsx
+++ b/src/items-palette/internal.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 
 import { getIsRtl } from "@cloudscape-design/component-toolkit/internal";
-import SpaceBetween from "@cloudscape-design/components/space-between";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
 
 import { getDataAttributes } from "../internal/base-component/get-data-attributes";
 import { InternalBaseComponentProps } from "../internal/base-component/use-base-component";
@@ -72,7 +72,7 @@ export function InternalItemsPalette<D>({
   return (
     <div ref={__internalRootRef} {...getDataAttributes(rest)}>
       <div ref={paletteRef} className={styles.root}>
-        <SpaceBetween size="l">
+        <ColumnLayout columns={3}>
           {items.map((item) => (
             <ItemContainer
               ref={(elem) => {
@@ -100,7 +100,7 @@ export function InternalItemsPalette<D>({
               {(hasDropTarget) => renderItem(item, { showPreview: hasDropTarget })}
             </ItemContainer>
           ))}
-        </SpaceBetween>
+        </ColumnLayout>
       </div>
 
       <LiveRegion>{announcement}</LiveRegion>


### PR DESCRIPTION
### Description

Introduces column layout to board items palette to fit more items when there is enough horizontal space in both side and bottom orientations of the panel.

Rel: [4xTcAv3PK6h2]

### How has this been tested?

* Manual testing in test pages and demos

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
