### PR TITLE
chore: Update board item's i18n strings

### DIFF
--- a/pages/shared/i18n.ts
+++ b/pages/shared/i18n.ts
@@ -57,10 +57,10 @@ export const clientI18nStrings = {
 export const boardItemI18nStrings: BoardItemProps.I18nStrings = {
   dragHandleAriaLabel: "Drag handle",
   dragHandleAriaDescription:
-    "Use Space or Enter to activate drag, arrow keys to move, Space or Enter to submit, or Escape to discard.",
+    "Use Space or Enter to activate drag, arrow keys to move, Space or Enter to submit, or Escape to discard. Be sure to temporarily disable any screen reader navigation feature that may interfere with the functionality of the arrow keys.",
   resizeHandleAriaLabel: "Resize handle",
   resizeHandleAriaDescription:
-    "Use Space or Enter to activate resize, arrow keys to move, Space or Enter to submit, or Escape to discard.",
+    "Use Space or Enter to activate resize, arrow keys to move, Space or Enter to submit, or Escape to discard. Be sure to temporarily disable any screen reader navigation feature that may interfere with the functionality of the arrow keys.",
 };
 
 export const itemsPaletteI18nStrings: ItemsPaletteProps.I18nStrings<ItemData> = {


### PR DESCRIPTION
### Description

Add instructions to temp disable keyboard navigation while resizing/moving.
Why? A screen reader's keyboard navigation mode may intercept arrow key presses. We can't disable that with an appropriate role, that's why we extend the drag handlers description with that information.

Updated copy got approved, see CR-180476213.

Related links, issue #, if available: 
- CR-180476213
- AWSUI-60203

### How has this been tested?

- verified updated description on VoiceOver

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
