### PR TITLE
chore: Extract common visual theme code into helper function

### DIFF
--- a/src/internal/base-component/use-telemetry.ts
+++ b/src/internal/base-component/use-telemetry.ts
@@ -4,9 +4,11 @@
 import { ComponentConfiguration, useComponentMetrics } from "@cloudscape-design/component-toolkit/internal";
 
 import { PACKAGE_SOURCE, PACKAGE_VERSION, THEME } from "../environment";
+import { getVisualTheme } from "../utils/get-visual-theme";
 import { useVisualRefresh } from "./use-visual-refresh";
 
 export function useTelemetry(componentName: string, config?: ComponentConfiguration) {
-  const theme = useVisualRefresh() ? "vr" : THEME;
+  const isVisualRefresh = useVisualRefresh();
+  const theme = getVisualTheme(THEME, isVisualRefresh);
   useComponentMetrics(componentName, { packageSource: PACKAGE_SOURCE, packageVersion: PACKAGE_VERSION, theme }, config);
 }

--- a/src/internal/utils/__tests__/get-visual-theme.test.ts
+++ b/src/internal/utils/__tests__/get-visual-theme.test.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+
+import { getVisualTheme } from "../../../../lib/components/internal/utils/get-visual-theme";
+
+describe("getVisualTheme", () => {
+  it("returns vr when theme is polaris and VR is active", () => {
+    expect(getVisualTheme("polaris", true)).toBe("vr");
+  });
+
+  it("returns polaris when theme is polaris and VR is not active", () => {
+    expect(getVisualTheme("polaris", false)).toBe("polaris");
+  });
+
+  it("returns defined theme by default", () => {
+    expect(getVisualTheme("custom", false)).toBe("custom");
+    expect(getVisualTheme("custom", true)).toBe("custom");
+  });
+});

--- a/src/internal/utils/get-visual-theme.ts
+++ b/src/internal/utils/get-visual-theme.ts
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const getVisualTheme = (theme: string, isVR: boolean) => {
+  if (theme === "polaris" && isVR) {
+    return "vr";
+  }
+
+  return theme;
+};


### PR DESCRIPTION
### Description

Ports over helper function from https://github.com/cloudscape-design/components/pull/3355

Related links, issue #, if available: n/a

### How has this been tested?

- Copied over unit tests

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
