### PR TITLE
fix: Board dnd stuck state

### DIFF
--- a/src/internal/dnd-controller/__tests__/controller.test.ts
+++ b/src/internal/dnd-controller/__tests__/controller.test.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { useDraggable } from "../../../../lib/components/internal/dnd-controller/controller";
+
+describe("controller idempotent guards", () => {
+  const draggableItem = { id: "item-1", data: {} };
+  const getCollisionRect = () => ({ top: 0, bottom: 100, left: 0, right: 100 });
+
+  test("submitTransition is a no-op when no transition is active", () => {
+    const { result } = renderHook(() => useDraggable({ draggableItem, getCollisionRect }));
+    expect(() => result.current.submitTransition()).not.toThrow();
+  });
+
+  test("discardTransition is a no-op when no transition is active", () => {
+    const { result } = renderHook(() => useDraggable({ draggableItem, getCollisionRect }));
+    expect(() => result.current.discardTransition()).not.toThrow();
+  });
+});

--- a/src/internal/dnd-controller/controller.ts
+++ b/src/internal/dnd-controller/controller.ts
@@ -90,6 +90,9 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
    * Removes transition and issues a "submit" event.
    */
   public submit() {
+    if (!this.transition) {
+      return;
+    }
     this.emit("submit");
     this.transition = null;
   }
@@ -98,6 +101,9 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
    * Removes transition and issues a "discard" event.
    */
   public discard() {
+    if (!this.transition) {
+      return;
+    }
     this.emit("discard");
     this.transition = null;
   }

--- a/src/internal/item-container/__tests__/item-container.test.tsx
+++ b/src/internal/item-container/__tests__/item-container.test.tsx
@@ -142,6 +142,60 @@ describe("keyboard interaction", () => {
   });
 });
 
+describe("hook swap on pointer down", () => {
+  afterEach(vi.resetAllMocks);
+
+  test("switching from resize to drag discards the previous interaction", () => {
+    const { getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
+
+    // Start a resize interaction
+    fireEvent(getByTestId("resize-handle"), new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    fireEvent(getByTestId("resize-handle"), new MouseEvent("pointerup", { bubbles: true }));
+
+    // Simulate an active transition via the mock controller
+    act(() => {
+      mockController.start({
+        interactionType: "pointer",
+        operation: "resize",
+        draggableItem: defaultProps.item,
+        collisionRect: { top: 0, bottom: 0, left: 0, right: 0 },
+        coordinates: new Coordinates({ x: 0, y: 0 }),
+      } as DragAndDropData);
+    });
+
+    mockDraggable.discardTransition.mockClear();
+
+    // Now pointer-down on the drag handle — should discard the resize transition
+    fireEvent(getByTestId("drag-handle"), new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    expect(mockDraggable.discardTransition).toHaveBeenCalled();
+  });
+
+  test("switching from drag to resize discards the previous interaction", () => {
+    const { getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
+
+    // Start a drag interaction
+    fireEvent(getByTestId("drag-handle"), new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    fireEvent(getByTestId("drag-handle"), new MouseEvent("pointerup", { bubbles: true }));
+
+    // Simulate an active transition via the mock controller
+    act(() => {
+      mockController.start({
+        interactionType: "pointer",
+        operation: "reorder",
+        draggableItem: defaultProps.item,
+        collisionRect: { top: 0, bottom: 0, left: 0, right: 0 },
+        coordinates: new Coordinates({ x: 0, y: 0 }),
+      } as DragAndDropData);
+    });
+
+    mockDraggable.discardTransition.mockClear();
+
+    // Now pointer-down on the resize handle — should discard the drag transition
+    fireEvent(getByTestId("resize-handle"), new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    expect(mockDraggable.discardTransition).toHaveBeenCalled();
+  });
+});
+
 test("does not renders in portal when item in reorder state by a pointer", () => {
   const { container, getByTestId } = render(<ItemContainer {...defaultProps} placed={true} />);
   expect(container).toContainElement(getByTestId("drag-handle"));

--- a/src/internal/item-container/index.tsx
+++ b/src/internal/item-container/index.tsx
@@ -372,10 +372,15 @@ function ItemContainerComponent(
     }
     initialPointerDownPosition.current = { x: event.clientX, y: event.clientY };
 
-    if (operation === "drag") {
-      selectedHook.current = dragInteractionHook;
-    } else {
-      selectedHook.current = resizeInteractionHook;
+    const nextHook = operation === "drag" ? dragInteractionHook : resizeInteractionHook;
+
+    // Discard any in-progress interaction before switching to a different hook.
+    if (selectedHook.current !== nextHook) {
+      selectedHook.current.processBlur();
+      if (transition) {
+        draggableApi.discardTransition();
+      }
+      selectedHook.current = nextHook;
     }
     selectedHook.current.processPointerDown(event.nativeEvent);
   }
@@ -489,13 +494,13 @@ function ItemContainerComponent(
   const dragHookProps: UseInternalDragHandleInteractionStateProps = {
     onDndStartAction: (event) => handlePointerInteractionStart(event, "drag"),
     onDndActiveAction: onHandleDndTransitionActive,
-    onDndEndAction: () => transition && draggableApi.submitTransition(),
+    onDndEndAction: () => draggableApi.submitTransition(),
     onUapActionStartAction: () => handleIncrementalTransition("drag"),
   };
   const resizeHookProps: UseInternalDragHandleInteractionStateProps = {
     onDndStartAction: (event) => handlePointerInteractionStart(event, "resize"),
     onDndActiveAction: onHandleDndTransitionActive,
-    onDndEndAction: () => transition && draggableApi.submitTransition(),
+    onDndEndAction: () => draggableApi.submitTransition(),
     onUapActionStartAction: () => handleIncrementalTransition("resize"),
   };
 


### PR DESCRIPTION
### Description
Fixes a bug where pointer state gets permanently stuck after switching between drag and resize interactions without completing the first one.

dry run: 7928057582

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?
Checkout : https://cloudscape.design/examples/react/configurable-dashboard.html 

https://github.com/user-attachments/assets/c0e222bd-7ad6-48a5-97da-24211a088d9b

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
