### PR TITLE
chore: allow fork pr deployment for test pages

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -29,4 +29,3 @@ jobs:
     secrets: inherit
     with:
       artifact-name: dev-pages
-      deployment-path: dist

--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -1,0 +1,14 @@
+name: Deploy fork preview
+
+on:
+  workflow_run:
+    workflows: ["Build, lint and test"]
+    types:
+      - completed
+
+jobs:
+  fork-preview:
+    uses: cloudscape-design/actions/.github/workflows/deploy-fork-preview.yml@main
+    secrets: inherit
+    with:
+      artifact-name: dev-pages

--- a/.github/workflows/deploy-fork-preview.yml
+++ b/.github/workflows/deploy-fork-preview.yml
@@ -6,6 +6,12 @@ on:
     types:
       - completed
 
+permissions:
+  id-token: write
+  actions: read
+  contents: read
+  deployments: write
+
 jobs:
   fork-preview:
     uses: cloudscape-design/actions/.github/workflows/deploy-fork-preview.yml@main


### PR DESCRIPTION
### Description
Enables dev page previews for forked pull requests by triggering the reusable deployment workflow after the build completes and deploying the generated dev-pages artifact.

Related: https://github.com/cloudscape-design/actions/pull/122
Similar PR: https://github.com/cloudscape-design/chat-components/pull/146, 

<!-- Include a summary of the changes and the related issue. -->

<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: n/a

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
