### PR TITLE
fix: Stabilize QueryContainer JSX shape

### DIFF
--- a/pages/dnd/containers.tsx
+++ b/pages/dnd/containers.tsx
@@ -52,10 +52,12 @@ export function QueryContainer({
   children,
   minWidth = 0,
   minHeight = 0,
+  showBorder = true,
 }: {
   children: (size: { width?: number; height?: number }) => ReactNode;
   minWidth?: number;
   minHeight?: number;
+  showBorder?: boolean;
 }) {
   const [size, containerQueryRef] = useContainerQuery((entry) => ({
     height: entry.contentBoxHeight,
@@ -65,18 +67,11 @@ export function QueryContainer({
   const normalizedWidth = Math.max(size?.width ?? 0, minWidth);
   const normalizedHeight = Math.max(size?.height ?? 0, minHeight);
 
-  const useScroll = (size?.width ?? 0) < minWidth || (size?.height ?? 0) < minHeight;
-  const content = children({ width: normalizedWidth, height: normalizedHeight });
-
   return (
     <div ref={containerQueryRef} style={{ height: "100%", width: "100%" }}>
-      {useScroll ? (
-        <ScrollableContainer width={minWidth} height={minHeight}>
-          {content}
-        </ScrollableContainer>
-      ) : (
-        content
-      )}
+      <ScrollableContainer width={minWidth} height={minHeight} showBorder={showBorder}>
+        {children({ width: normalizedWidth, height: normalizedHeight })}
+      </ScrollableContainer>
     </div>
   );
 }

--- a/pages/dnd/items.tsx
+++ b/pages/dnd/items.tsx
@@ -138,7 +138,7 @@ export const demoWidgets: ItemWidgets = {
           {() => (
             <TwoColContainer
               left={
-                <QueryContainer minHeight={200}>
+                <QueryContainer minHeight={200} showBorder={false}>
                   {({ height = 0 }) => (
                     <SpaceBetween size="xs">
                       <Box fontSize="heading-s" fontWeight="bold">
@@ -150,7 +150,7 @@ export const demoWidgets: ItemWidgets = {
                 </QueryContainer>
               }
               right={
-                <QueryContainer>
+                <QueryContainer showBorder={false}>
                   {({ width = 0, height = 0 }) => {
                     let size: "small" | "medium" | "large" = "small";
                     if (width > 300 && height > 300) {


### PR DESCRIPTION
### Description

`QueryContainer` in the DnD dev pages runtime-toggled between two JSX shapes (`<ScrollableContainer>{content}</ScrollableContainer>` vs raw `{content}`) based on `useContainerQuery` measurement. The differing JSX types at the same position caused React to unmount and remount the content subtree on every flip, generating fresh `useId` values and re-triggering downstream observers. Style toggles on the same state (`overflow` / `minHeight` / `minWidth`) added a layout feedback loop, together producing chart geometry oscillation on the `widget-container/content-permutations` page and a `Maximum update depth exceeded` warning.

<!-- Include a summary of the changes and the related issue. -->
<!-- Also include relevant motivation and context. -->

Related links, issue #, if available: AWSUI-62091

### How has this been tested?

<!-- How did you test to verify your changes? -->

<!-- How can reviewers test these changes efficiently? -->

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
