### PR TITLE
feat: Add rowHeight prop to Board for customizable row height

### DIFF
--- a/pages/board/row-height.page.tsx
+++ b/pages/board/row-height.page.tsx
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
+import Box from "@cloudscape-design/components/box";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+import { Board, BoardItem, BoardProps } from "../../lib/components";
+import { ScreenshotArea } from "../screenshot-area";
+import { boardI18nStrings, boardItemI18nStrings } from "../shared/i18n";
+import { ItemData } from "../shared/interfaces";
+
+const rowHeightOptions: Array<undefined | number> = [undefined, 32, 48, 64, 96];
+
+const initialItems: ReadonlyArray<BoardProps.Item<ItemData>> = [
+  {
+    id: "one",
+    columnSpan: 2,
+    rowSpan: 2,
+    definition: {},
+    data: { title: "Content-light widget", description: "", content: "Two rows tall" },
+  },
+  {
+    id: "two",
+    columnSpan: 2,
+    rowSpan: 4,
+    definition: {},
+    data: { title: "Taller widget", description: "", content: "Four rows tall" },
+  },
+  {
+    id: "three",
+    columnSpan: 2,
+    rowSpan: 3,
+    definition: {},
+    data: { title: "Medium widget", description: "", content: "Three rows tall" },
+  },
+];
+
+export default function BoardRowHeightPage() {
+  const [rowHeight, setRowHeight] = useState<undefined | number>(undefined);
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <ScreenshotArea>
+      <Box margin="l">
+        <SpaceBetween size="m">
+          <Header variant="h1" description="Use the buttons to change the board row height.">
+            Board row height (AWSUI-61568)
+          </Header>
+
+          <div>
+            <SpaceBetween size="xs" direction="horizontal">
+              {rowHeightOptions.map((option) => (
+                <button
+                  key={String(option)}
+                  type="button"
+                  data-testid={`row-height-${option ?? "default"}`}
+                  aria-pressed={rowHeight === option}
+                  onClick={() => setRowHeight(option)}
+                >
+                  {option === undefined ? "Default (96px)" : `${option}px`}
+                </button>
+              ))}
+            </SpaceBetween>
+          </div>
+
+          <Box data-testid="current-row-height">
+            Current rowHeight: {rowHeight === undefined ? "default" : rowHeight}
+          </Box>
+
+          <Board
+            items={items}
+            rowHeight={rowHeight}
+            renderItem={(item) => (
+              <BoardItem header={<Header>{item.data.title}</Header>} i18nStrings={boardItemI18nStrings}>
+                {item.data.content}
+              </BoardItem>
+            )}
+            i18nStrings={boardI18nStrings}
+            onItemsChange={(event) => setItems(event.detail.items)}
+            empty="No items"
+          />
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -534,6 +534,17 @@ The function takes the item and its associated actions (BoardProps.ItemActions) 
       "optional": false,
       "type": "(item: BoardProps.Item<D>, actions: BoardProps.ItemActions) => JSX.Element",
     },
+    {
+      "description": "Overrides the height, in pixels, of a single board row. Board items span a whole number of
+rows, so this value controls the granularity of their vertical sizing (for example, a smaller
+row height lets content-light items occupy less vertical space and increases sizing precision).
+
+When not set, the density-based default is used (96px in comfortable mode, 76px in compact mode),
+which preserves the existing behavior. Values that are not positive finite numbers are ignored.",
+      "name": "rowHeight",
+      "optional": true,
+      "type": "number",
+    },
   ],
   "regions": [
     {

--- a/src/board/__tests__/board-row-height.test.tsx
+++ b/src/board/__tests__/board-row-height.test.tsx
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, expect, test } from "vitest";
+
+import Board from "../../../lib/components/board";
+import { defaultProps } from "./utils";
+
+import gridStyles from "../../../lib/components/internal/grid/styles.css.js";
+
+const ROW_HEIGHT_CSS_PROPERTY = "--awsui-board-row-height";
+
+beforeAll(() => {
+  // jsdom does not support this function
+  document.elementFromPoint = () => null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function getGridRoot(container: HTMLElement) {
+  return container.querySelector<HTMLElement>(`.${gridStyles.grid}`)!;
+}
+
+test("uses the default row height when rowHeight is not provided", () => {
+  const { container } = render(<Board {...defaultProps} />);
+
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("96px");
+});
+
+test("forwards a custom rowHeight to the underlying grid", () => {
+  const { container } = render(<Board {...defaultProps} rowHeight={32} />);
+
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("32px");
+});
+
+test("ignores a non-positive rowHeight and keeps the default", () => {
+  const { container } = render(<Board {...defaultProps} rowHeight={0} />);
+
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("96px");
+});
+
+test("does not leak rowHeight to the root element as a data attribute", () => {
+  const { container } = render(<Board {...defaultProps} rowHeight={48} />);
+
+  // The root board element must not receive a `rowHeight` attribute.
+  expect(container.firstElementChild?.hasAttribute("rowheight")).toBe(false);
+});

--- a/src/board/interfaces.ts
+++ b/src/board/interfaces.ts
@@ -72,6 +72,16 @@ export interface BoardProps<D = DataFallbackType> {
    * When items are loading the slot can be used to render the loading indicator.
    */
   empty: ReactNode;
+
+  /**
+   * Overrides the height, in pixels, of a single board row. Board items span a whole number of
+   * rows, so this value controls the granularity of their vertical sizing (for example, a smaller
+   * row height lets content-light items occupy less vertical space and increases sizing precision).
+   *
+   * When not set, the density-based default is used (96px in comfortable mode, 76px in compact mode),
+   * which preserves the existing behavior. Values that are not positive finite numbers are ignored.
+   */
+  rowHeight?: number;
 }
 
 export namespace BoardProps {

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -41,6 +41,7 @@ export function InternalBoard<D>({
   onItemsChange,
   empty,
   i18nStrings,
+  rowHeight,
   __internalRootRef,
   ...rest
 }: BoardProps<D> & InternalBaseComponentProps) {
@@ -237,6 +238,7 @@ export function InternalBoard<D>({
             isRtl={isRtl}
             columns={itemsLayout.columns}
             layout={[...placeholdersLayout.items, ...itemsLayout.items]}
+            rowHeight={rowHeight}
           >
             {(gridContext) => {
               const layoutShift = transition?.layoutShift ?? removeTransition?.layoutShift;

--- a/src/internal/grid/__tests__/grid.test.tsx
+++ b/src/internal/grid/__tests__/grid.test.tsx
@@ -21,6 +21,12 @@ const defaultProps: GridProps = {
   ),
 };
 
+const ROW_HEIGHT_CSS_PROPERTY = "--awsui-board-row-height";
+
+function getGridRoot(container: HTMLElement) {
+  return container.querySelector<HTMLElement>(`.${gridStyles.grid}`)!;
+}
+
 test("renders children content", async () => {
   const result = render(<Grid {...defaultProps} />);
 
@@ -51,4 +57,23 @@ test("assigns styles on individual elements", () => {
     "grid-column-start": "3",
     "grid-column-end": "span 2",
   });
+});
+
+test("uses the default row height when rowHeight is not provided", () => {
+  const { container } = render(<Grid {...defaultProps} />);
+
+  // Defaults to the comfortable-mode row height (96px).
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("96px");
+});
+
+test("applies a custom row height when rowHeight is provided", () => {
+  const { container } = render(<Grid {...defaultProps} rowHeight={32} />);
+
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("32px");
+});
+
+test.each([0, -10, NaN, Infinity])("ignores invalid rowHeight value %s and falls back to default", (rowHeight) => {
+  const { container } = render(<Grid {...defaultProps} rowHeight={rowHeight} />);
+
+  expect(getGridRoot(container).style.getPropertyValue(ROW_HEIGHT_CSS_PROPERTY)).toBe("96px");
 });

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Children, useRef } from "react";
+import { Children, CSSProperties, useRef } from "react";
 import clsx from "clsx";
 
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
@@ -19,12 +19,21 @@ const GRID_GAP = { comfortable: 20, compact: 16 };
 /* Matches grid-auto-rows in CSS. */
 const ROWSPAN_HEIGHT = { comfortable: 96, compact: 76 };
 
-export default function Grid({ layout, children: render, columns, isRtl }: GridProps) {
+/* Custom property consumed by grid-auto-rows in CSS to allow overriding the row height. */
+const ROW_HEIGHT_CSS_PROPERTY = "--awsui-board-row-height";
+
+function isValidRowHeight(rowHeight?: number): rowHeight is number {
+  return typeof rowHeight === "number" && isFinite(rowHeight) && rowHeight > 0;
+}
+
+export default function Grid({ layout, children: render, columns, isRtl, rowHeight }: GridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const [gridWidth, containerQueryRef] = useContainerQuery((entry) => entry.contentBoxWidth, []);
   const densityMode = useDensityMode(gridRef);
   const gridGap = GRID_GAP[densityMode];
-  const rowspanHeight = ROWSPAN_HEIGHT[densityMode];
+  // An explicit row height, when provided, overrides the density-based default so that
+  // consumers can achieve finer-grained vertical sizing.
+  const rowspanHeight = isValidRowHeight(rowHeight) ? rowHeight : ROWSPAN_HEIGHT[densityMode];
 
   // The below getters translate relative grid units into size/offset values in pixels.
   const getWidth = (colspan: number) => {
@@ -44,9 +53,17 @@ export default function Grid({ layout, children: render, columns, isRtl }: GridP
 
   const zipped = zipTwoArrays(layout, Children.toArray(children));
 
+  // Keep the rendered CSS row height in sync with the pixel math above. The custom property is
+  // always set to the resolved value so grid-auto-rows matches getHeight() exactly.
+  const gridStyle = { [ROW_HEIGHT_CSS_PROPERTY]: `${rowspanHeight}px` } as CSSProperties;
+
   const ref = useMergeRefs(gridRef, containerQueryRef);
   return (
-    <div ref={ref} className={clsx(styles.grid, styles[`grid-${densityMode}`], styles[`columns-${columns}`])}>
+    <div
+      ref={ref}
+      className={clsx(styles.grid, styles[`grid-${densityMode}`], styles[`columns-${columns}`])}
+      style={gridStyle}
+    >
       {zipped.map(([item, children]) => (
         <GridItem key={item.id} item={item}>
           {children}

--- a/src/internal/grid/interfaces.ts
+++ b/src/internal/grid/interfaces.ts
@@ -10,6 +10,12 @@ export interface GridProps {
   columns: number;
   children?: (context: GridContext) => ReactNode;
   isRtl?: () => boolean;
+  /**
+   * Overrides the default height (in pixels) of a single grid row. When not set, the
+   * density-based default is used (96px in comfortable mode, 76px in compact mode).
+   * Values that are not positive finite numbers are ignored and the default is used.
+   */
+  rowHeight?: number;
 }
 
 export interface GridContext {

--- a/src/internal/grid/styles.scss
+++ b/src/internal/grid/styles.scss
@@ -10,12 +10,13 @@ $grid-col-width: minmax(0, 1fr);
   display: grid;
   /* Matches GRID_GAP constant used for calculations. */
   gap: 20px;
-  /* Matches ROWSPAN_HEIGHT constant used for calculations. */
-  grid-auto-rows: 96px;
+  /* Matches ROWSPAN_HEIGHT constant used for calculations. The custom property is set by the
+     Grid component and defaults to the comfortable-mode row height when absent. */
+  grid-auto-rows: var(--awsui-board-row-height, 96px);
 
   &-compact {
     gap: 16px;
-    grid-auto-rows: 76px;
+    grid-auto-rows: var(--awsui-board-row-height, 76px);
   }
 }
 


### PR DESCRIPTION
### Description

Adds an opt-in, backward-compatible `rowHeight` prop to `Board` that lets consumers override the default grid row height. This addresses the feature request in [AWSUI-61568](https://taskei.amazon.dev/tasks/AWSUI-61568) (*"Customizable board row size"* / `ROWSPAN_HEIGHT` customization).

**Motivation:** the board row height is currently fixed per density (96px comfortable / 76px compact), and the minimum item height is 2 rows (≈192px). Data-light widgets are therefore forced to reserve a lot of vertical white space, and customers have resorted to patching internal CSS (which breaks the Cloudscape contract). This prop gives first-class, finer-grained vertical sizing — e.g. `rowHeight={32}` yields 3× the sizing precision and lets a 2-row widget be 64px instead of 192px.

**What changed:**
- New `BoardProps.rowHeight?: number` (px). When unset, the existing density-based defaults are used, so current boards render identically.
- The value flows `Board` → `InternalBoard` → internal `Grid`, where it drives **both** the pixel math (`getHeight`) used for layout/resize **and** the rendered `grid-auto-rows` via a `--awsui-board-row-height` CSS custom property — keeping layout math and rendering in sync.
- Invalid values (non-positive or non-finite) are ignored and fall back to the density default.

This reuses the existing Board/Grid layout pipeline; no changes to `minRowSpan`/layout semantics.

Related links, issue #, if available: AWSUI-61568

> Note: the ticket is a raw feature request without a finalized API spec (it only references `ROWSPAN_HEIGHT` customization and a Quip doc). This PR implements a `rowHeight` prop as the opt-in, contract-friendly surface for that request. Happy to rename/rescope (e.g. per-density object, or a `BoardItem`-level minimum) during review.

### How has this been tested?

- `npm run build`, `eslint`, `stylelint`, and `tsc` (unit + e2e project typecheck) all pass.
- Unit tests (`npm run test:unit`) pass — **330 tests, 34 files**. New coverage added:
  - `src/internal/grid/__tests__/grid.test.tsx` — default row height, custom override, and invalid-value fallback (0/negative/NaN/Infinity).
  - `src/board/__tests__/board-row-height.test.tsx` — prop is forwarded to the grid, default is preserved when unset, non-positive values fall back, and the prop does not leak onto the root DOM element.
- API-docs snapshot regenerated to include the new prop.
- New dev page `pages/board/row-height.page.tsx` renders a board with buttons to switch between default / 32 / 48 / 64 / 96px row heights for manual/visual verification.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ ✅ Prop documented in `BoardProps`; API-docs snapshot updated.
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._ ✅ Opt-in; defaults unchanged.
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._ ✅ Uses a standard CSS custom property with a static fallback.
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ ⚠️ No a11y-affecting changes (layout sizing only); dev page provided for manual verification.

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._ N/A — no URL handling.

#### Testing

- _Changes are covered with new/existing unit tests?_ ✅ New grid + board unit tests.
- _Changes are covered with new/existing integration tests?_ ➖ Dev page added; visual/integration coverage can be added in review if desired.
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
