### PR TITLE
feat: support multiple independent Board instances (v0) [WIP]

### DIFF
--- a/pages/board-dnd-provider/multi-instance.page.tsx
+++ b/pages/board-dnd-provider/multi-instance.page.tsx
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
+import Box from "@cloudscape-design/components/box";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+import { Board, BoardDndProvider, BoardItem, BoardProps, ItemsPalette, ItemsPaletteProps } from "../../lib/components";
+import { createLetterItems } from "../dnd/items";
+import { boardI18nStrings, boardItemI18nStrings, itemsPaletteI18nStrings } from "../shared/i18n";
+import { ItemData } from "../shared/interfaces";
+
+const isolatedBoardOne = createLetterItems([["A", "B"]])!.boardItems;
+const isolatedBoardTwo = createLetterItems([["C", "D"]])!.boardItems;
+const sharedGroup = createLetterItems([["E", "F"]], ["G", "H", "I", "J"])!;
+
+function renderBoardItem(item: BoardProps.Item<ItemData>) {
+  return (
+    <BoardItem header={<Header>{item.data.title}</Header>} i18nStrings={boardItemI18nStrings}>
+      {item.data.content}
+    </BoardItem>
+  );
+}
+
+function DemoBoard({
+  items,
+  onItemsChange,
+}: {
+  items: readonly BoardProps.Item<ItemData>[];
+  onItemsChange: (items: readonly BoardProps.Item<ItemData>[]) => void;
+}) {
+  return (
+    <Board<ItemData>
+      items={items}
+      i18nStrings={boardI18nStrings}
+      empty={<Box>No items</Box>}
+      onItemsChange={({ detail }) => onItemsChange(detail.items)}
+      renderItem={renderBoardItem}
+    />
+  );
+}
+
+function DemoPalette({ items }: { items: readonly ItemsPaletteProps.Item<ItemData>[] }) {
+  return (
+    <ItemsPalette<ItemData>
+      items={items}
+      i18nStrings={itemsPaletteI18nStrings}
+      renderItem={(item) => renderBoardItem(item as BoardProps.Item<ItemData>)}
+    />
+  );
+}
+
+/**
+ * Demonstrates multiple independent Board instances on a single page using
+ * `BoardDndProvider`.
+ *
+ * - Boards 1 and 2 are each wrapped in their own `BoardDndProvider`, so their
+ *   drag-and-drop is fully isolated: you cannot drag an item from one into the
+ *   other.
+ * - The "shared group" wraps a palette and a board in a single
+ *   `BoardDndProvider`, so items can be dragged from the palette into that board.
+ */
+export default function BoardDndProviderMultiInstancePage() {
+  const [boardOne, setBoardOne] = useState(isolatedBoardOne);
+  const [boardTwo, setBoardTwo] = useState(isolatedBoardTwo);
+  const [sharedBoard, setSharedBoard] = useState(sharedGroup.boardItems);
+
+  return (
+    <SpaceBetween size="xl">
+      <Header variant="h1">Board multi-instance (BoardDndProvider)</Header>
+
+      <SpaceBetween size="l">
+        <Header variant="h2">Isolated boards (separate providers)</Header>
+        <div data-testid="isolated-board-1">
+          <BoardDndProvider>
+            <DemoBoard items={boardOne} onItemsChange={setBoardOne} />
+          </BoardDndProvider>
+        </div>
+        <div data-testid="isolated-board-2">
+          <BoardDndProvider>
+            <DemoBoard items={boardTwo} onItemsChange={setBoardTwo} />
+          </BoardDndProvider>
+        </div>
+      </SpaceBetween>
+
+      <SpaceBetween size="l">
+        <Header variant="h2">Shared group (one provider: palette + board)</Header>
+        <div data-testid="shared-group">
+          <BoardDndProvider>
+            <SpaceBetween size="m">
+              <DemoBoard items={sharedBoard} onItemsChange={setSharedBoard} />
+              <DemoPalette items={sharedGroup.paletteItems} />
+            </SpaceBetween>
+          </BoardDndProvider>
+        </div>
+      </SpaceBetween>
+    </SpaceBetween>
+  );
+}

--- a/scripts/pluralize.js
+++ b/scripts/pluralize.js
@@ -5,6 +5,7 @@ const pluralizationMap = {
   BoardItem: "BoardItems",
   ItemsPalette: "ItemsPalettes",
   PaletteItem: "PaletteItems",
+  BoardDndProvider: "BoardDndProviders",
 };
 
 function pluralizeComponentName(componentName) {

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -548,6 +548,52 @@ When items are loading the slot can be used to render the loading indicator.",
 }
 `;
 
+exports[`definition for 'board-dnd-provider' matches the snapshot 1`] = `
+{
+  "dashCaseName": "board-dnd-provider",
+  "description": "\`BoardDndProvider\` establishes an isolated drag-and-drop context for the
+\`Board\` (and optional \`ItemsPalette\`) components rendered within it.
+
+Use it to render multiple independent Board instances on the same page:
+- Wrap each board in its own \`BoardDndProvider\` to fully isolate their
+  drag-and-drop interactions.
+- Wrap several boards (and/or a palette) in a single \`BoardDndProvider\` to let
+  them share one context, so items can be dragged between them.
+
+Boards rendered without a \`BoardDndProvider\` keep the default page-wide
+drag-and-drop context, preserving backwards compatibility.
+
+This component is additive and opt-in: existing usages that do not use it are
+unaffected. The wrapper element uses \`display: contents\`, so it does not
+affect the layout of the wrapped board components.",
+  "events": [],
+  "functions": [],
+  "name": "BoardDndProvider",
+  "properties": [],
+  "regions": [
+    {
+      "description": "The board components to render within a single, isolated drag-and-drop context.
+
+Any \`Board\` and \`ItemsPalette\` instances rendered inside the same
+\`BoardDndProvider\` share one drag-and-drop context and can exchange items
+with each other (for example, dragging an item from one board to another,
+or from a palette into a board).
+
+Board components rendered in different \`BoardDndProvider\` instances are
+isolated from one another, which is what enables multiple independent Board
+instances on a single page.
+
+Board components rendered outside of any \`BoardDndProvider\` continue to use
+the shared page-wide drag-and-drop context (the default, backwards-compatible
+behavior).",
+      "isDefault": true,
+      "name": "children",
+    },
+  ],
+  "releaseStatus": "stable",
+}
+`;
+
 exports[`definition for 'board-item' matches the snapshot 1`] = `
 {
   "dashCaseName": "board-item",

--- a/src/__tests__/__snapshots__/test-utils-wrappers.test.tsx.snap
+++ b/src/__tests__/__snapshots__/test-utils-wrappers.test.tsx.snap
@@ -10,12 +10,14 @@ import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
 export { ElementWrapper };
 
 import BoardWrapper from './board';
+import BoardDndProviderWrapper from './board-dnd-provider';
 import BoardItemWrapper from './board-item';
 import ItemsPaletteWrapper from './items-palette';
 import PaletteItemWrapper from './palette-item';
 
 
 export { BoardWrapper };
+export { BoardDndProviderWrapper };
 export { BoardItemWrapper };
 export { ItemsPaletteWrapper };
 export { PaletteItemWrapper };
@@ -51,6 +53,34 @@ findAllBoards(selector?: string): Array<BoardWrapper>;
  * @returns {BoardWrapper | null}
  */
 findClosestBoard(): BoardWrapper | null;
+/**
+ * Returns the wrapper of the first BoardDndProvider that matches the specified CSS selector.
+ * If no CSS selector is specified, returns the wrapper of the first BoardDndProvider.
+ * If no matching BoardDndProvider is found, returns \`null\`.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BoardDndProviderWrapper | null}
+ */
+findBoardDndProvider(selector?: string): BoardDndProviderWrapper | null;
+
+/**
+ * Returns an array of BoardDndProvider wrapper that matches the specified CSS selector.
+ * If no CSS selector is specified, returns all of the BoardDndProviders inside the current wrapper.
+ * If no matching BoardDndProvider is found, returns an empty array.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {Array<BoardDndProviderWrapper>}
+ */
+findAllBoardDndProviders(selector?: string): Array<BoardDndProviderWrapper>;
+
+/**
+ * Returns the wrapper of the closest parent BoardDndProvider for the current element,
+ * or the element itself if it is an instance of BoardDndProvider.
+ * If no BoardDndProvider is found, returns \`null\`.
+ *
+ * @returns {BoardDndProviderWrapper | null}
+ */
+findClosestBoardDndProvider(): BoardDndProviderWrapper | null;
 /**
  * Returns the wrapper of the first BoardItem that matches the specified CSS selector.
  * If no CSS selector is specified, returns the wrapper of the first BoardItem.
@@ -152,6 +182,19 @@ ElementWrapper.prototype.findBoard = function(selector) {
 ElementWrapper.prototype.findAllBoards = function(selector) {
   return this.findAllComponents(BoardWrapper, selector);
 };
+ElementWrapper.prototype.findBoardDndProvider = function(selector) {
+  let rootSelector = \`.\${BoardDndProviderWrapper.rootSelector}\`;
+  if("legacyRootSelector" in BoardDndProviderWrapper && BoardDndProviderWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${BoardDndProviderWrapper.rootSelector}, .\${BoardDndProviderWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoardDndProviderWrapper);
+};
+
+ElementWrapper.prototype.findAllBoardDndProviders = function(selector) {
+  return this.findAllComponents(BoardDndProviderWrapper, selector);
+};
 ElementWrapper.prototype.findBoardItem = function(selector) {
   let rootSelector = \`.\${BoardItemWrapper.rootSelector}\`;
   if("legacyRootSelector" in BoardItemWrapper && BoardItemWrapper.legacyRootSelector){
@@ -197,6 +240,11 @@ ElementWrapper.prototype.findClosestBoard = function() {
   // https://github.com/microsoft/TypeScript/issues/29132
   return (this as any).findClosestComponent(BoardWrapper);
 };
+ElementWrapper.prototype.findClosestBoardDndProvider = function() {
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findClosestComponent(BoardDndProviderWrapper);
+};
 ElementWrapper.prototype.findClosestBoardItem = function() {
   // casting to 'any' is needed to avoid this issue with generics
   // https://github.com/microsoft/TypeScript/issues/29132
@@ -232,12 +280,14 @@ import { appendSelector } from '@cloudscape-design/test-utils-core/utils';
 export { ElementWrapper };
 
 import BoardWrapper from './board';
+import BoardDndProviderWrapper from './board-dnd-provider';
 import BoardItemWrapper from './board-item';
 import ItemsPaletteWrapper from './items-palette';
 import PaletteItemWrapper from './palette-item';
 
 
 export { BoardWrapper };
+export { BoardDndProviderWrapper };
 export { BoardItemWrapper };
 export { ItemsPaletteWrapper };
 export { PaletteItemWrapper };
@@ -262,6 +312,23 @@ findBoard(selector?: string): BoardWrapper;
  * @returns {MultiElementWrapper<BoardWrapper>}
  */
 findAllBoards(selector?: string): MultiElementWrapper<BoardWrapper>;
+/**
+ * Returns a wrapper that matches the BoardDndProviders with the specified CSS selector.
+ * If no CSS selector is specified, returns a wrapper that matches BoardDndProviders.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {BoardDndProviderWrapper}
+ */
+findBoardDndProvider(selector?: string): BoardDndProviderWrapper;
+
+/**
+ * Returns a multi-element wrapper that matches BoardDndProviders with the specified CSS selector.
+ * If no CSS selector is specified, returns a multi-element wrapper that matches BoardDndProviders.
+ *
+ * @param {string} [selector] CSS Selector
+ * @returns {MultiElementWrapper<BoardDndProviderWrapper>}
+ */
+findAllBoardDndProviders(selector?: string): MultiElementWrapper<BoardDndProviderWrapper>;
 /**
  * Returns a wrapper that matches the BoardItems with the specified CSS selector.
  * If no CSS selector is specified, returns a wrapper that matches BoardItems.
@@ -329,6 +396,19 @@ ElementWrapper.prototype.findBoard = function(selector) {
 
 ElementWrapper.prototype.findAllBoards = function(selector) {
   return this.findAllComponents(BoardWrapper, selector);
+};
+ElementWrapper.prototype.findBoardDndProvider = function(selector) {
+  let rootSelector = \`.\${BoardDndProviderWrapper.rootSelector}\`;
+  if("legacyRootSelector" in BoardDndProviderWrapper && BoardDndProviderWrapper.legacyRootSelector){
+    rootSelector = \`:is(.\${BoardDndProviderWrapper.rootSelector}, .\${BoardDndProviderWrapper.legacyRootSelector})\`;
+  }
+  // casting to 'any' is needed to avoid this issue with generics
+  // https://github.com/microsoft/TypeScript/issues/29132
+  return (this as any).findComponent(selector ? appendSelector(selector, rootSelector) : rootSelector, BoardDndProviderWrapper);
+};
+
+ElementWrapper.prototype.findAllBoardDndProviders = function(selector) {
+  return this.findAllComponents(BoardDndProviderWrapper, selector);
 };
 ElementWrapper.prototype.findBoardItem = function(selector) {
   let rootSelector = \`.\${BoardItemWrapper.rootSelector}\`;

--- a/src/__tests__/default-props.tsx
+++ b/src/__tests__/default-props.tsx
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { BoardItemProps, BoardProps, ItemsPaletteProps } from "../../lib/components";
+import type { BoardDndProviderProps, BoardItemProps, BoardProps, ItemsPaletteProps } from "../../lib/components";
 import { ItemContextWrapper } from "../board-item/__tests__/board-item-wrapper";
 
 const boardProps: BoardProps = {
@@ -38,10 +38,15 @@ const itemsPaletteProps: ItemsPaletteProps = {
   },
 };
 
+const boardDndProviderProps: BoardDndProviderProps = {
+  children: null,
+};
+
 export const defaultProps = {
   board: boardProps,
   "board-item": boardItemProps,
   "items-palette": itemsPaletteProps,
+  "board-dnd-provider": boardDndProviderProps,
 } as const;
 
 export const wrappers = {

--- a/src/board-dnd-provider/index.tsx
+++ b/src/board-dnd-provider/index.tsx
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import clsx from "clsx";
+
+import { getDataAttributes } from "../internal/base-component/get-data-attributes";
+import useBaseComponent from "../internal/base-component/use-base-component";
+import { DndContextProvider } from "../internal/dnd-controller/dnd-context";
+import { applyDisplayName } from "../internal/utils/apply-display-name";
+import type { BoardDndProviderProps } from "./interfaces";
+
+import styles from "./styles.css.js";
+
+export type { BoardDndProviderProps };
+
+/**
+ * `BoardDndProvider` establishes an isolated drag-and-drop context for the
+ * `Board` (and optional `ItemsPalette`) components rendered within it.
+ *
+ * Use it to render multiple independent Board instances on the same page:
+ * - Wrap each board in its own `BoardDndProvider` to fully isolate their
+ *   drag-and-drop interactions.
+ * - Wrap several boards (and/or a palette) in a single `BoardDndProvider` to let
+ *   them share one context, so items can be dragged between them.
+ *
+ * Boards rendered without a `BoardDndProvider` keep the default page-wide
+ * drag-and-drop context, preserving backwards compatibility.
+ *
+ * This component is additive and opt-in: existing usages that do not use it are
+ * unaffected. The wrapper element uses `display: contents`, so it does not
+ * affect the layout of the wrapped board components.
+ */
+export default function BoardDndProvider({ children, ...rest }: BoardDndProviderProps) {
+  const baseComponentProps = useBaseComponent("BoardDndProvider");
+  return (
+    <div
+      ref={baseComponentProps.__internalRootRef}
+      className={clsx(styles.root)}
+      {...getDataAttributes(rest as Record<string, string>)}
+    >
+      <DndContextProvider>{children}</DndContextProvider>
+    </div>
+  );
+}
+
+applyDisplayName(BoardDndProvider, "BoardDndProvider");

--- a/src/board-dnd-provider/interfaces.ts
+++ b/src/board-dnd-provider/interfaces.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ReactNode } from "react";
+
+export interface BoardDndProviderProps {
+  /**
+   * The board components to render within a single, isolated drag-and-drop context.
+   *
+   * Any `Board` and `ItemsPalette` instances rendered inside the same
+   * `BoardDndProvider` share one drag-and-drop context and can exchange items
+   * with each other (for example, dragging an item from one board to another,
+   * or from a palette into a board).
+   *
+   * Board components rendered in different `BoardDndProvider` instances are
+   * isolated from one another, which is what enables multiple independent Board
+   * instances on a single page.
+   *
+   * Board components rendered outside of any `BoardDndProvider` continue to use
+   * the shared page-wide drag-and-drop context (the default, backwards-compatible
+   * behavior).
+   */
+  children: ReactNode;
+}

--- a/src/board-dnd-provider/styles.scss
+++ b/src/board-dnd-provider/styles.scss
@@ -1,0 +1,10 @@
+/*
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+*/
+
+.root {
+  /* Layout-neutral wrapper: the provider only supplies a DnD context and should
+     not introduce its own box in the layout of the wrapped board components. */
+  display: contents;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,3 +9,6 @@ export type { ItemsPaletteProps } from "./items-palette";
 
 export { default as BoardItem } from "./board-item";
 export type { BoardItemProps } from "./board-item";
+
+export { default as BoardDndProvider } from "./board-dnd-provider";
+export type { BoardDndProviderProps } from "./board-dnd-provider";

--- a/src/internal/dnd-controller/__tests__/dnd-context.test.tsx
+++ b/src/internal/dnd-controller/__tests__/dnd-context.test.tsx
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import {
+  DragAndDropController,
+  DropTargetContext,
+  useDndController,
+} from "../../../../lib/components/internal/dnd-controller/controller";
+import { DndContextProvider } from "../../../../lib/components/internal/dnd-controller/dnd-context";
+
+function renderController(wrapper?: ({ children }: { children: ReactNode }) => JSX.Element) {
+  return renderHook(() => useDndController(), { wrapper }).result.current;
+}
+
+describe("DnD context isolation", () => {
+  test("returns the shared global controller when no provider is present", () => {
+    const a = renderController();
+    const b = renderController();
+    expect(a).toBeInstanceOf(DragAndDropController);
+    // Both no-provider consumers resolve to the same shared singleton (backwards compatible).
+    expect(a).toBe(b);
+  });
+
+  test("provides a dedicated controller per provider instance", () => {
+    const wrapperA = ({ children }: { children: ReactNode }) => <DndContextProvider>{children}</DndContextProvider>;
+    const wrapperB = ({ children }: { children: ReactNode }) => <DndContextProvider>{children}</DndContextProvider>;
+
+    const controllerA = renderController(wrapperA);
+    const controllerB = renderController(wrapperB);
+
+    expect(controllerA).toBeInstanceOf(DragAndDropController);
+    expect(controllerB).toBeInstanceOf(DragAndDropController);
+    // Separate providers => isolated controllers (independent Board instances).
+    expect(controllerA).not.toBe(controllerB);
+    // A provider isolates from the global singleton too.
+    expect(controllerA).not.toBe(renderController());
+  });
+
+  test("keeps a stable controller across re-renders of the same provider", () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <DndContextProvider>{children}</DndContextProvider>;
+    const { result, rerender } = renderHook(() => useDndController(), { wrapper });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+
+describe("DragAndDropController droppable registry isolation", () => {
+  const context: DropTargetContext = { scale: () => ({ width: 0, height: 0 }) };
+
+  test("droppables registered on one controller are not visible to another", () => {
+    const controllerA = new DragAndDropController();
+    const controllerB = new DragAndDropController();
+
+    controllerA.addDroppable("a-1", context, document.createElement("div"));
+
+    expect(controllerA.getDroppables().map(([id]) => id)).toEqual(["a-1"]);
+    // The second controller has an independent registry, so cross-board collisions cannot happen.
+    expect(controllerB.getDroppables()).toEqual([]);
+  });
+});

--- a/src/internal/dnd-controller/controller.ts
+++ b/src/internal/dnd-controller/controller.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ReactNode, useEffect } from "react";
+import { createContext, ReactNode, useContext, useEffect } from "react";
 
 import { useStableCallback } from "@cloudscape-design/component-toolkit/internal";
 
@@ -63,7 +63,7 @@ interface Transition {
   startCoordinates: Coordinates;
 }
 
-class DragAndDropController extends EventEmitter<DragAndDropEvents> {
+export class DragAndDropController extends EventEmitter<DragAndDropEvents> {
   private droppables = new Map<ItemId, Droppable>();
   private transition: null | Transition = null;
 
@@ -166,12 +166,39 @@ class DragAndDropController extends EventEmitter<DragAndDropEvents> {
   }
 }
 
-// Controller is a singleton and is shared between all d&d elements.
+// The default controller is a singleton and is shared between all d&d elements
+// that are not wrapped in a dedicated DnD context provider. This preserves the
+// historical single-board behavior (all boards and palettes on a page interact).
 const controller = new DragAndDropController();
 
+/**
+ * The DnD context determines which draggables and droppables can interact with
+ * each other. Every board component reads its controller from this context.
+ *
+ * By default (no provider) the shared global {@link controller} singleton is
+ * used, which keeps the original behavior where all Board/ItemsPalette instances
+ * on the page belong to a single drag-and-drop context.
+ *
+ * Wrapping a subtree in a provider that supplies a dedicated
+ * {@link DragAndDropController} instance isolates that subtree's drag-and-drop
+ * from the rest of the page. This is what enables multiple independent Board
+ * instances on one page - see the public `BoardDndProvider` component and the
+ * internal `DndContextProvider` helper.
+ */
+export const DndControllerContext = createContext<DragAndDropController>(controller);
+
+/**
+ * Returns the drag-and-drop controller for the current DnD context.
+ * Falls back to the shared global singleton when no provider is present.
+ */
+export function useDndController(): DragAndDropController {
+  return useContext(DndControllerContext);
+}
+
 export function useDragSubscription<K extends keyof DragAndDropEvents>(event: K, handler: DragAndDropEvents[K]) {
+  const controller = useDndController();
   const stableHandler = useStableCallback(handler);
-  useEffect(() => controller.on(event, stableHandler), [event, stableHandler]);
+  useEffect(() => controller.on(event, stableHandler), [controller, event, stableHandler]);
 }
 
 export function useDraggable({
@@ -181,6 +208,7 @@ export function useDraggable({
   draggableItem: Item;
   getCollisionRect: (operation: Operation, coordinates: Coordinates, dropTarget: null | DropTargetContext) => Rect;
 }) {
+  const controller = useDndController();
   return {
     start(operation: Operation, interactionType: InteractionType, startCoordinates: Coordinates) {
       controller.start({ operation, interactionType, draggableItem, getCollisionRect, startCoordinates });
@@ -212,8 +240,9 @@ export function useDroppable({
   context: DropTargetContext;
   getElement: () => HTMLElement;
 }) {
+  const controller = useDndController();
   useEffect(() => {
     controller.addDroppable(itemId, context, getElement());
     return () => controller.removeDroppable(itemId);
-  }, [itemId, context, getElement]);
+  }, [controller, itemId, context, getElement]);
 }

--- a/src/internal/dnd-controller/dnd-context.tsx
+++ b/src/internal/dnd-controller/dnd-context.tsx
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ReactNode, useRef } from "react";
+
+import { DndControllerContext, DragAndDropController } from "./controller";
+
+export interface DndContextProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Provides an isolated drag-and-drop controller to its subtree.
+ *
+ * All board components rendered within the same provider share one DnD context
+ * and can therefore exchange items (e.g. drag between two boards, or from a
+ * palette into a board). Components rendered in separate providers are isolated
+ * from one another, which enables multiple independent Board instances on a
+ * single page.
+ *
+ * The controller instance is created lazily and kept stable for the lifetime of
+ * the provider so that subscriptions and droppable registrations remain valid
+ * across re-renders.
+ */
+export function DndContextProvider({ children }: DndContextProviderProps) {
+  const controllerRef = useRef<DragAndDropController>();
+  if (!controllerRef.current) {
+    controllerRef.current = new DragAndDropController();
+  }
+  return <DndControllerContext.Provider value={controllerRef.current}>{children}</DndControllerContext.Provider>;
+}

--- a/src/test-utils/dom/board-dnd-provider/index.ts
+++ b/src/test-utils/dom/board-dnd-provider/index.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { ComponentWrapper } from "@cloudscape-design/test-utils-core/dom";
+
+import boardDndProviderStyles from "../../../board-dnd-provider/styles.selectors.js";
+
+export default class BoardDndProviderWrapper extends ComponentWrapper {
+  static rootSelector: string = boardDndProviderStyles.root;
+}


### PR DESCRIPTION
### Description

**[WIP / first-cut v0]** Enables **multiple independent `Board` instances on a single page**.

Today the drag-and-drop `DragAndDropController` is a module-level **singleton** shared by every `Board`/`ItemsPalette` on the page (`src/internal/dnd-controller/controller.ts`). All droppables register into one shared registry, so collisions and drops "leak" between boards and independent boards cannot be isolated.

This change makes the DnD controller **context-scoped** and adds an opt-in provider:

- `DragAndDropController` is now exported and the DnD hooks (`useDragSubscription`, `useDraggable`, `useDroppable`) read their controller from a new React context (`DndControllerContext`).
- The context **defaults to the existing global singleton**, so all current usages are unchanged (fully backward-compatible).
- New internal `DndContextProvider` mints a dedicated controller per subtree.
- New **public, opt-in** `BoardDndProvider` component wraps board components in an isolated DnD context:
  - Wrap each board in its **own** `BoardDndProvider` → boards are fully isolated.
  - Wrap several boards (and/or a palette) in **one** `BoardDndProvider` → they share a context and items can be dragged between them.
  - No provider → unchanged page-wide behavior.
- The provider wrapper uses `display: contents` so it is layout-neutral.

This is **additive and opt-in**. It is a coherent, buildable v0 to unblock the epic; it is **not** feature-complete (see remaining work).

Related links, issue #, if available: Tracking SIM AWSUI-56573.
> ⚠️ Ticket mismatch: `AWSUI-56573` in Taskei currently resolves to an unrelated "Aperture Form Submission" (a Console visual-appearance opt-out feedback entry), not the Board multi-instance epic. Implemented per the assigned epic description; please re-point the tracking ID if needed.

#### Done in this PR (v0)
- Context-scoped DnD controller with singleton fallback (backward-compatible).
- `DndContextProvider` (internal) + public `BoardDndProvider` (+ interfaces, styles, index export).
- Test-utils wrapper (`findBoardDndProvider` / `findAllBoardDndProviders`).
- Dev page: `pages/board-dnd-provider/multi-instance.page.tsx` (isolated boards + shared group).
- Unit tests for context isolation and per-instance controller registry.
- Regenerated documenter + test-utils API-doc snapshots for the new component.

#### Remaining work (follow-ups, out of scope for v0)
- Functional/visual e2e coverage proving pointer + keyboard DnD isolation across instances (drag between vs. isolate).
- Keyboard/screen-reader insertion across boards within a shared provider; announcements review.
- Auto-scroll / global drag-state styles are still partly global — audit for per-context scoping.
- Public API documentation (Usage tab) and examples.
- Decide the final public surface (dedicated `BoardDndProvider` vs. a prop on `Board`) and naming with the team.
- SSR/multiple-React-context edge cases; per-instance item identity guarantees when IDs collide across boards.

### How has this been tested?

- `npm run build` — green.
- `npm run test:unit` — **336 passed / 34 files** (incl. new `dnd-context` tests; snapshots regenerated).
- `eslint .` — **0 errors** (pre-existing warnings only).
- Manual: new dev page renders two isolated boards + one shared palette/board group.
- Not run here: `test:functional` / `test:visual` (Puppeteer e2e) — tracked as follow-up.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._ (partial — API docs follow-up)
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._ (yes — context defaults to the existing singleton)
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._ (follow-up)

#### Security

- _If the code handles URLs: all URLs are validated through the `checkSafeUrl` function._ (n/a)

#### Testing

- _Changes are covered with new/existing unit tests?_ (yes)
- _Changes are covered with new/existing integration tests?_ (follow-up)
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
