### PR TITLE
fix: Flip UAP inline-start/inline-end direction mapping in RTL

### DIFF
--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -3,7 +3,7 @@
 
 import { ReactElement } from "react";
 import { cleanup, fireEvent, render as libRender } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
@@ -14,6 +14,7 @@ import TooltipWrapper from "@cloudscape-design/components/test-utils/dom/interna
 
 import "@cloudscape-design/components/test-utils/dom";
 import BoardItem from "../../../lib/components/board-item";
+import { ItemContainer } from "../../../lib/components/internal/item-container";
 import createWrapper from "../../../lib/components/test-utils/dom";
 import { ItemContextWrapper } from "./board-item-wrapper";
 
@@ -132,5 +133,37 @@ describe("WidgetContainer", () => {
     expect(dragHandleWrapper.findVisibleDirectionButtonBlockEnd()).toBeDefined();
     expect(dragHandleWrapper.findVisibleDirectionButtonInlineStart()).toBeDefined();
     expect(dragHandleWrapper.findVisibleDirectionButtonInlineEnd()).toBeDefined();
+  });
+
+  test("maps the inline-start UAP button to the physical right direction in RTL", () => {
+    const onKeyMove = vi.fn();
+    libRender(
+      <div style={{ direction: "rtl" }}>
+        <ItemContainer
+          item={{ id: "1", data: { title: "Item 1" } }}
+          placed={true}
+          acquired={false}
+          transform={undefined}
+          inTransition={false}
+          getItemSize={() => ({ width: 1, minWidth: 1, maxWidth: 1, height: 1, minHeight: 1, maxHeight: 1 })}
+          isRtl={() => true}
+          onKeyMove={onKeyMove}
+        >
+          {() => <BoardItem i18nStrings={i18nStrings} />}
+        </ItemContainer>
+      </div>,
+    );
+
+    const dragHandleEl = createWrapper().findBoardItem()!.findDragHandle()!.getElement();
+    fireEvent(dragHandleEl, new MouseEvent("pointerdown", { bubbles: true }));
+    fireEvent(dragHandleEl, new MouseEvent("pointerup", { bubbles: true }));
+
+    const inlineStartButton = new DragHandleWrapper(document.body)
+      .findVisibleDirectionButtonInlineStart()!
+      .getElement();
+    fireEvent.click(inlineStartButton);
+
+    // In RTL the inline-start (left) UAP button must move the item in the physical "right" direction.
+    expect(onKeyMove).toHaveBeenCalledWith("right");
   });
 });

--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -167,5 +167,11 @@ describe("WidgetContainer", () => {
 
     // In RTL the inline-start button is rendered on the physical right, so it must move the item right.
     expect(onKeyMove).toHaveBeenCalledWith("right");
+
+    const inlineEndButton = new DragHandleWrapper(document.body).findVisibleDirectionButtonInlineEnd()!.getElement();
+    fireEvent.click(inlineEndButton);
+
+    // In RTL the inline-end button is rendered on the physical left, so it must move the item left.
+    expect(onKeyMove).toHaveBeenCalledWith("left");
   });
 });

--- a/src/board-item/__tests__/board-item.test.tsx
+++ b/src/board-item/__tests__/board-item.test.tsx
@@ -18,6 +18,8 @@ import { ItemContainer } from "../../../lib/components/internal/item-container";
 import createWrapper from "../../../lib/components/test-utils/dom";
 import { ItemContextWrapper } from "./board-item-wrapper";
 
+vi.mock("../../../lib/components/internal/dnd-controller/controller");
+
 const i18nStrings = {
   dragHandleAriaLabel: "Drag handle",
   resizeHandleAriaLabel: "Resize handle",
@@ -163,7 +165,7 @@ describe("WidgetContainer", () => {
       .getElement();
     fireEvent.click(inlineStartButton);
 
-    // In RTL the inline-start (left) UAP button must move the item in the physical "right" direction.
+    // In RTL the inline-start button is rendered on the physical right, so it must move the item right.
     expect(onKeyMove).toHaveBeenCalledWith("right");
   });
 });

--- a/src/board-item/internal.tsx
+++ b/src/board-item/internal.tsx
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { useId } from "react";
+import { useId, useRef } from "react";
 import clsx from "clsx";
 
+import { getIsRtl, useMergeRefs } from "@cloudscape-design/component-toolkit/internal";
 import Container from "@cloudscape-design/components/container";
 import { InternalDragHandleProps } from "@cloudscape-design/components/internal/do-not-use/drag-handle";
 
@@ -18,10 +19,13 @@ import type { BoardItemProps } from "./interfaces";
 
 import styles from "./styles.css.js";
 
-const mapToKeyboardDirection = (direction: InternalDragHandleProps.Direction) => {
+const mapToKeyboardDirection = (direction: InternalDragHandleProps.Direction, isRtl: boolean): Direction => {
+  // inline-start/inline-end are relative to the reading direction, but arrow keys
+  // map directly to cardinal directions. So we need to flip pointer presses based on
+  // the page's reading direction.
   const directionMap: Record<InternalDragHandleProps.Direction, Direction> = {
-    "inline-start": "left",
-    "inline-end": "right",
+    "inline-start": isRtl ? "right" : "left",
+    "inline-end": isRtl ? "left" : "right",
     "block-start": "up",
     "block-end": "down",
   };
@@ -40,6 +44,9 @@ export function InternalBoardItem({
 }: BoardItemProps & InternalBaseComponentProps) {
   const { dragHandle, resizeHandle, isActive, isDragActive, isHidden } = useItemContext();
 
+  const rootRef = useRef<HTMLDivElement>(null);
+  const mergedRootRef = useMergeRefs(rootRef, __internalRootRef);
+
   const dragHandleAriaLabelledBy = useId();
   const dragHandleAriaDescribedBy = useId();
 
@@ -53,7 +60,7 @@ export function InternalBoardItem({
   }
 
   return (
-    <div ref={__internalRootRef} className={styles.root} {...getDataAttributes(rest)}>
+    <div ref={mergedRootRef} className={styles.root} {...getDataAttributes(rest)}>
       <Container
         fitHeight={true}
         disableHeaderPaddings={true}
@@ -68,7 +75,9 @@ export function InternalBoardItem({
                 onKeyDown={dragHandle.onKeyDown}
                 activeState={dragHandle.activeState}
                 initialShowButtons={dragHandle.initialShowButtons}
-                onDirectionClick={(direction) => dragHandle.onDirectionClick(mapToKeyboardDirection(direction), "drag")}
+                onDirectionClick={(direction) => {
+                  dragHandle.onDirectionClick(mapToKeyboardDirection(direction, getIsRtl(rootRef.current)), "drag");
+                }}
                 dragHandleTooltipText={isDragActive ? undefined : i18nStrings.dragHandleTooltipText}
               />
             }
@@ -92,7 +101,7 @@ export function InternalBoardItem({
             onKeyDown={resizeHandle.onKeyDown}
             activeState={resizeHandle.activeState}
             onDirectionClick={(direction) => {
-              resizeHandle.onDirectionClick(mapToKeyboardDirection(direction), "resize");
+              resizeHandle.onDirectionClick(mapToKeyboardDirection(direction, getIsRtl(rootRef.current)), "resize");
             }}
             resizeHandleTooltipText={isDragActive ? undefined : i18nStrings.resizeHandleTooltipText}
           />


### PR DESCRIPTION
### Description

The left and right UAP buttons were flipped in RTL. It's because "inline-start" is left in LTR and right in RTL. Included this logic.

Related links, issue #, if available: AWSUI-62174

### How has this been tested?

Added a unit test.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
