### PR TITLE
feat: add configurable responsive columns to Board

### DIFF
--- a/pages/board/column-layout.page.tsx
+++ b/pages/board/column-layout.page.tsx
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+import { Board, BoardItem, BoardProps } from "../../lib/components";
+import { ScreenshotArea } from "../screenshot-area";
+import { boardI18nStrings, boardItemI18nStrings } from "../shared/i18n";
+import { ItemData } from "../shared/interfaces";
+
+const defaultColumnLayout = undefined;
+const eightColumnLayout: BoardProps.ColumnLayout = { default: 1, xs: 2, s: 4, m: 6, l: 8 };
+
+const initialItems: ReadonlyArray<BoardProps.Item<ItemData>> = Array.from({ length: 8 }, (_, index) => ({
+  id: `${index + 1}`,
+  columnSpan: 1,
+  rowSpan: 2,
+  data: {
+    title: `Widget ${index + 1}`,
+    description: "",
+    content: "Resize the page or this board's container to change the active column count.",
+  },
+}));
+
+export default function BoardColumnLayoutPage() {
+  const [columnLayout, setColumnLayout] = useState<BoardProps.ColumnLayout | undefined>(eightColumnLayout);
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <ScreenshotArea>
+      <Box margin="l">
+        <SpaceBetween size="m">
+          <Header
+            variant="h1"
+            description="Resize the page to verify that custom column counts follow Cloudscape container breakpoints."
+          >
+            Responsive board columns
+          </Header>
+
+          <SpaceBetween size="xs" direction="horizontal">
+            <Button
+              variant={columnLayout === defaultColumnLayout ? "primary" : "normal"}
+              onClick={() => setColumnLayout(defaultColumnLayout)}
+            >
+              Default columns
+            </Button>
+            <Button
+              variant={columnLayout === eightColumnLayout ? "primary" : "normal"}
+              onClick={() => setColumnLayout(eightColumnLayout)}
+            >
+              Up to eight columns
+            </Button>
+          </SpaceBetween>
+
+          <Board
+            columnLayout={columnLayout}
+            items={items}
+            renderItem={(item) => (
+              <BoardItem header={<Header>{item.data.title}</Header>} i18nStrings={boardItemI18nStrings}>
+                {item.data.content}
+              </BoardItem>
+            )}
+            i18nStrings={boardI18nStrings}
+            onItemsChange={(event) => setItems(event.detail.items)}
+            empty="No items"
+          />
+        </SpaceBetween>
+      </Box>
+    </ScreenshotArea>
+  );
+}

--- a/src/__tests__/__snapshots__/documenter.test.ts.snap
+++ b/src/__tests__/__snapshots__/documenter.test.ts.snap
@@ -334,6 +334,63 @@ The change detail has the following properties:
   "name": "Board",
   "properties": [
     {
+      "description": "Configures the number of grid columns used at Cloudscape container breakpoints.
+Values apply at the specified breakpoint and wider breakpoints until overridden.
+For example, \`{ default: 1, xs: 2, s: 4, l: 8 }\` uses one column by default,
+two columns at \`xs\`, four columns at \`s\` and \`m\`, and eight columns at \`l\` and \`xl\`.
+The breakpoints are \`default\` (up to 465px), \`xxs\` (over 465px), \`xs\` (over 688px),
+\`s\` (over 912px), \`m\` (over 1120px), \`l\` (over 1320px), and \`xl\` (over 1840px).
+
+When not set, the board uses its default responsive layout of one, two, four, or six columns.
+Unspecified breakpoints inherit the value from the closest narrower configured breakpoint.
+If there is no configured value at or below the active breakpoint, the default board layout is used.
+Invalid values that are not positive integers are ignored.",
+      "inlineType": {
+        "name": "Partial<Record<BoardProps.Breakpoint, number>>",
+        "properties": [
+          {
+            "name": "default",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "l",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "m",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "s",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "xl",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "xs",
+            "optional": true,
+            "type": "number",
+          },
+          {
+            "name": "xxs",
+            "optional": true,
+            "type": "number",
+          },
+        ],
+        "type": "object",
+      },
+      "name": "columnLayout",
+      "optional": true,
+      "type": "Partial<Record<BoardProps.Breakpoint, number>>",
+    },
+    {
       "description": "An object containing all the necessary localized strings required by the component.
 
 Live announcements:

--- a/src/board/__tests__/board.test.tsx
+++ b/src/board/__tests__/board.test.tsx
@@ -41,6 +41,12 @@ describe("Board", () => {
     expect(item.getElement().textContent).toBe("Item 2");
   });
 
+  test("does not pass columnLayout to the root element", () => {
+    const { container } = render(<Board {...defaultProps} columnLayout={{ default: 1, l: 8 }} />);
+
+    expect(container.firstElementChild?.hasAttribute("columnlayout")).toBe(false);
+  });
+
   test("pressing 'Escape' when there is no transition does not cause errors", () => {
     render(<Board {...defaultProps} />);
     const itemDragHandle = createWrapper().findBoard()!.findItemById("2")!.findDragHandle();

--- a/src/board/interfaces.ts
+++ b/src/board/interfaces.ts
@@ -72,9 +72,28 @@ export interface BoardProps<D = DataFallbackType> {
    * When items are loading the slot can be used to render the loading indicator.
    */
   empty: ReactNode;
+
+  /**
+   * Configures the number of grid columns used at Cloudscape container breakpoints.
+   * Values apply at the specified breakpoint and wider breakpoints until overridden.
+   * For example, `{ default: 1, xs: 2, s: 4, l: 8 }` uses one column by default,
+   * two columns at `xs`, four columns at `s` and `m`, and eight columns at `l` and `xl`.
+   * The breakpoints are `default` (up to 465px), `xxs` (over 465px), `xs` (over 688px),
+   * `s` (over 912px), `m` (over 1120px), `l` (over 1320px), and `xl` (over 1840px).
+   *
+   * When not set, the board uses its default responsive layout of one, two, four, or six columns.
+   * Unspecified breakpoints inherit the value from the closest narrower configured breakpoint.
+   * If there is no configured value at or below the active breakpoint, the default board layout is used.
+   * Invalid values that are not positive integers are ignored.
+   */
+  columnLayout?: BoardProps.ColumnLayout;
 }
 
 export namespace BoardProps {
+  export type Breakpoint = "default" | "xxs" | "xs" | "s" | "m" | "l" | "xl";
+
+  export type ColumnLayout = Partial<Record<Breakpoint, number>>;
+
   export interface Item<D = DataFallbackType> {
     id: string;
     data: D;

--- a/src/board/internal.tsx
+++ b/src/board/internal.tsx
@@ -42,11 +42,12 @@ export function InternalBoard<D>({
   onItemsChange,
   empty,
   i18nStrings,
+  columnLayout,
   __internalRootRef,
   ...rest
 }: BoardProps<D> & InternalBaseComponentProps) {
   const containerAccessRef = useRef<HTMLDivElement>(null);
-  const [currentColumns, containerQueryRef] = useContainerColumns();
+  const [currentColumns, containerQueryRef] = useContainerColumns(columnLayout);
   const containerRef = useMergeRefs(containerAccessRef, containerQueryRef);
   const itemContainerRef = useRef<{ [id: ItemId]: ItemContainerRef }>({});
 

--- a/src/internal/__tests__/breakpoints.test.ts
+++ b/src/internal/__tests__/breakpoints.test.ts
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from "vitest";
+
+import { resolveContainerColumns } from "../../../lib/components/internal/breakpoints";
+
+describe("resolveContainerColumns", () => {
+  test.each([
+    [0, 1],
+    [687, 1],
+    [688, 2],
+    [911, 2],
+    [912, 4],
+    [2099, 4],
+    [2100, 6],
+  ])("preserves the default layout at %ipx", (width, expectedColumns) => {
+    expect(resolveContainerColumns(width)).toBe(expectedColumns);
+  });
+
+  test.each([
+    [0, 1],
+    [688, 1],
+    [689, 2],
+    [912, 2],
+    [913, 4],
+    [1320, 4],
+    [1321, 8],
+    [2400, 8],
+  ])("uses responsive column configuration at %ipx", (width, expectedColumns) => {
+    expect(resolveContainerColumns(width, { default: 1, xs: 2, s: 4, l: 8 })).toBe(expectedColumns);
+  });
+
+  test("uses the default layout below the first configured breakpoint", () => {
+    expect(resolveContainerColumns(1200, { l: 8 })).toBe(4);
+    expect(resolveContainerColumns(1400, { l: 8 })).toBe(8);
+  });
+
+  test("ignores invalid column counts", () => {
+    expect(resolveContainerColumns(1400, { default: 1, s: 0, m: -1, l: 2.5 })).toBe(1);
+  });
+});

--- a/src/internal/breakpoints.ts
+++ b/src/internal/breakpoints.ts
@@ -3,19 +3,70 @@
 
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
 
-export function useContainerColumns() {
-  const [columns, containerQueryRef] = useContainerQuery((entry) => {
-    if (entry.contentBoxWidth < 688) {
-      return 1;
+import type { BoardProps } from "../board/interfaces";
+
+const BREAKPOINTS: ReadonlyArray<readonly [BoardProps.Breakpoint, number]> = [
+  ["xl", 1840],
+  ["l", 1320],
+  ["m", 1120],
+  ["s", 912],
+  ["xs", 688],
+  ["xxs", 465],
+  ["default", -1],
+];
+
+function getDefaultColumns(width: number) {
+  if (width < 688) {
+    return 1;
+  }
+  if (width < 912) {
+    return 2;
+  }
+  if (width < 2100) {
+    return 4;
+  }
+  return 6;
+}
+
+function isValidColumnCount(columns: number | undefined): columns is number {
+  return typeof columns === "number" && Number.isInteger(columns) && columns > 0;
+}
+
+function getMatchingBreakpoint(width: number) {
+  return BREAKPOINTS.find(([, minWidth]) => width > minWidth)![0];
+}
+
+function getConfiguredColumns(columnLayout: BoardProps.ColumnLayout, actualBreakpoint: BoardProps.Breakpoint) {
+  const actualBreakpointIndex = BREAKPOINTS.findIndex(([breakpoint]) => breakpoint === actualBreakpoint);
+
+  for (const [breakpoint] of BREAKPOINTS.slice(actualBreakpointIndex)) {
+    const columns = columnLayout[breakpoint];
+    if (isValidColumnCount(columns)) {
+      return columns;
     }
-    if (entry.contentBoxWidth < 912) {
-      return 2;
-    }
-    if (entry.contentBoxWidth < 2100) {
-      return 4;
-    }
-    return 6;
-  }, []);
+  }
+
+  return null;
+}
+
+export function resolveContainerColumns(width: number, columnLayout?: BoardProps.ColumnLayout) {
+  if (!columnLayout) {
+    return getDefaultColumns(width);
+  }
+
+  const breakpoint = getMatchingBreakpoint(width);
+
+  return getConfiguredColumns(columnLayout, breakpoint) ?? getDefaultColumns(width);
+}
+
+export function useContainerColumns(columnLayout?: BoardProps.ColumnLayout) {
+  const { default: defaultColumns, xxs, xs, s, m, l, xl } = columnLayout ?? {};
+  const [columns, containerQueryRef] = useContainerQuery(
+    (entry) => {
+      return resolveContainerColumns(entry.contentBoxWidth, { default: defaultColumns, xxs, xs, s, m, l, xl });
+    },
+    [defaultColumns, xxs, xs, s, m, l, xl],
+  );
 
   return [columns ?? 0, containerQueryRef] as const;
 }

--- a/src/internal/grid/__tests__/grid.test.tsx
+++ b/src/internal/grid/__tests__/grid.test.tsx
@@ -31,8 +31,15 @@ test("renders children content", async () => {
 test("assigns styles on root element", () => {
   const { container } = render(<Grid {...defaultProps} />);
 
-  const root = container.querySelector(`.${gridStyles.grid}`);
-  expect(root).toHaveClass(gridStyles["columns-4"]);
+  const root = container.querySelector<HTMLElement>(`.${gridStyles.grid}`);
+  expect(root?.style.getPropertyValue("--awsui-board-grid-columns")).toBe("4");
+});
+
+test("supports an arbitrary number of columns", () => {
+  const { container } = render(<Grid {...defaultProps} columns={8} />);
+
+  const root = container.querySelector<HTMLElement>(`.${gridStyles.grid}`);
+  expect(root?.style.getPropertyValue("--awsui-board-grid-columns")).toBe("8");
 });
 
 test("assigns styles on individual elements", () => {

--- a/src/internal/grid/grid.tsx
+++ b/src/internal/grid/grid.tsx
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Children, useRef } from "react";
+import { Children, CSSProperties, useRef } from "react";
 import clsx from "clsx";
 
 import { useContainerQuery } from "@cloudscape-design/component-toolkit";
@@ -18,6 +18,8 @@ const GRID_GAP = { comfortable: 20, compact: 16 };
 
 /* Matches grid-auto-rows in CSS. */
 const ROWSPAN_HEIGHT = { comfortable: 96, compact: 76 };
+
+const GRID_COLUMNS_CSS_PROPERTY = "--awsui-board-grid-columns";
 
 export default function Grid({ layout, children: render, columns, isRtl }: GridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
@@ -45,8 +47,9 @@ export default function Grid({ layout, children: render, columns, isRtl }: GridP
   const zipped = zipTwoArrays(layout, Children.toArray(children));
 
   const ref = useMergeRefs(gridRef, containerQueryRef);
+  const gridStyle = { [GRID_COLUMNS_CSS_PROPERTY]: columns } as CSSProperties;
   return (
-    <div ref={ref} className={clsx(styles.grid, styles[`grid-${densityMode}`], styles[`columns-${columns}`])}>
+    <div ref={ref} className={clsx(styles.grid, styles[`grid-${densityMode}`])} style={gridStyle}>
       {zipped.map(([item, children]) => (
         <GridItem key={item.id} item={item}>
           {children}

--- a/src/internal/grid/styles.scss
+++ b/src/internal/grid/styles.scss
@@ -12,27 +12,12 @@ $grid-col-width: minmax(0, 1fr);
   gap: 20px;
   /* Matches ROWSPAN_HEIGHT constant used for calculations. */
   grid-auto-rows: 96px;
+  grid-template-columns: repeat(var(--awsui-board-grid-columns), $grid-col-width);
 
   &-compact {
     gap: 16px;
     grid-auto-rows: 76px;
   }
-}
-
-.grid.columns-1 {
-  grid-template-columns: $grid-col-width;
-}
-
-.grid.columns-2 {
-  grid-template-columns: repeat(2, $grid-col-width);
-}
-
-.grid.columns-4 {
-  grid-template-columns: repeat(4, $grid-col-width);
-}
-
-.grid.columns-6 {
-  grid-template-columns: repeat(6, $grid-col-width);
 }
 
 .grid__item {


### PR DESCRIPTION
### Description

Adds an optional, backward-compatible `columnLayout` prop to `Board`. Consumers can configure column counts at Cloudscape container breakpoints such as `xs`, `s`, `m`, and `l`.

Unspecified breakpoints inherit the nearest narrower configured value. Existing Board behavior remains unchanged when the prop is omitted.

Related links, issue #, if available: https://github.com/cloudscape-design/components/issues/3256

### How has this been tested?

- `npm run build`
- `npm run lint`
- `npm run test:unit` — 375 tests pass
- Manually verified responsive layouts and keyboard movement on the new development page

The functional test stage was not run locally because ChromeDriver is unavailable.

<details>
   <summary>Review checklist</summary>

_The following items are to be evaluated by the author(s) and the reviewer(s)._

#### Correctness

- _Changes include appropriate documentation updates._
- _Changes are backward-compatible if not indicated, see [`CONTRIBUTING.md`](CONTRIBUTING.md#public-apis)._
- _Changes do not include unsupported browser features, see [`CONTRIBUTING.md`](CONTRIBUTING.md#browsers-support)._
- _Changes were manually tested for accessibility, see [accessibility guidelines](https://cloudscape.design/foundation/core-principles/accessibility/)._

#### Security

- _If the code handles URLs: all URLs are validated through [the `checkSafeUrl` function](https://github.com/cloudscape-design/components/blob/main/src/internal/utils/check-safe-url.ts)._

#### Testing

- _Changes are covered with new/existing unit tests?_
- _Changes are covered with new/existing integration tests?_
</details>

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.